### PR TITLE
Add item rooms, weighted items, and minimap improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,9 @@
   // ======= 配置 =======
   const CONFIG = {
     roomW: 800, roomH: 600,
-    grid: 5, // 地图 5x5
+    grid: 9, // 更大的潜在网格，随机游走生成不规则结构
     roomsToMake: 9, // 随机游走生成房间数量
+    itemRooms: 1,
     player: {speed: 210, radius: 12, hp: 6, fireCd: 360, tearSpeed: 230, tearLife: 0.65}, // fireCd 毫秒
     enemy: {
       baseHP: 2,
@@ -106,6 +107,42 @@
   function randRange(min,max){return min + (max-min)*rand()}
   function clamp(v,a,b){return Math.max(a,Math.min(b,v))}
   function dist(a,b){const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy)}
+  function adjustFireRate(player, delta){
+    if(!player) return;
+    const currentRate = player.fireInterval>0 ? 1000/player.fireInterval : 0;
+    const newRate = Math.max(0.1, currentRate + delta);
+    player.fireInterval = 1000 / newRate;
+    player.fireCd = Math.min(player.fireCd, player.fireInterval);
+  }
+  const DIRS = [
+    {di:-1,dj:0,key:'up',opp:'down'},
+    {di:1,dj:0,key:'down',opp:'up'},
+    {di:0,dj:-1,key:'left',opp:'right'},
+    {di:0,dj:1,key:'right',opp:'left'}
+  ];
+  const ITEM_POOL = [
+    {
+      id:'onion',
+      name:'洋葱',
+      weight:5,
+      description:'泪腺更发达，射速 +0.75 次/秒',
+      apply(player){ adjustFireRate(player, 0.75); }
+    },
+    {
+      id:'tar',
+      name:'焦油抹布',
+      weight:3,
+      description:'伤害 +0.5，泪滴更厚重',
+      apply(player){ player.damage = +(player.damage + 0.5).toFixed(2); }
+    },
+    {
+      id:'sneaker',
+      name:'小短跑鞋',
+      weight:4,
+      description:'移动速度 +35，轻盈不少',
+      apply(player){ player.speed += 35; }
+    }
+  ];
   const HUDL = document.getElementById('hud-left');
   const HUDR = document.getElementById('hud-right');
   const HUDS = document.getElementById('hud-stats');
@@ -154,12 +191,19 @@
     constructor(i,j){
       this.i=i; this.j=j;
       this.doors={up:false,down:false,left:false,right:false};
-      this.cleared=false; this.visited=false;
+      this.cleared=false; this.visited=false; this.discovered=false;
       this.enemies=[]; this.pickups=[];
       this.isBoss=false; this.bossEntity=null; this.bossDefeated=false; this.bossName=''; this.introPlayed=false;
+      this.isItemRoom=false; this.itemData=null; this.itemClaimed=false; this.itemSpawned=false;
     }
     center(){ return {x: CONFIG.roomW/2, y: CONFIG.roomH/2}; }
     spawnEnemies(depth){
+      if(this.isItemRoom){
+        this.enemies = [];
+        this.cleared = true;
+        this.ensureItem();
+        return this.enemies;
+      }
       if(this.isBoss){
         if(this.bossDefeated){ this.enemies = []; return this.enemies; }
         if(!this.bossEntity || this.bossEntity.dead){
@@ -181,44 +225,69 @@
       }
       return this.enemies;
     }
+    ensureItem(){
+      if(!this.isItemRoom || this.itemClaimed) return;
+      if(!this.itemData){ this.itemData = rollItem(); }
+      if(this.itemSpawned) return;
+      const c = this.center();
+      this.pickups = this.pickups.filter(p=>p.type!=='item');
+      this.pickups.push(makeItemPickup(c.x, c.y, this));
+      this.itemSpawned = true;
+    }
   }
 
   class Dungeon{
     constructor(){
       this.gridN = CONFIG.grid;
       // 创建空房
-      this.rooms = Array.from({length:this.gridN}, (_,i)=> Array.from({length:this.gridN},(_,j)=>null));
+      this.rooms = Array.from({length:this.gridN}, ()=> Array.from({length:this.gridN},()=>null));
       const mid = Math.floor(this.gridN/2);
-      let ci=mid, cj=mid;
-      const visited = new Set([key(ci,cj)]);
-      this.rooms[ci][cj] = new Room(ci,cj);
-      // 随机游走生成若干房间
-      for(let n=1;n<CONFIG.roomsToMake;n++){
-        const dir = Math.floor(rand()*4);
-        const di = [ -1, 1, 0, 0 ][dir];
-        const dj = [ 0, 0, -1, 1 ][dir];
-        const ni = clamp(ci+di, 0, this.gridN-1);
-        const nj = clamp(cj+dj, 0, this.gridN-1);
-        ci=ni; cj=nj;
-        if(!this.rooms[ci][cj]) this.rooms[ci][cj] = new Room(ci,cj);
-        visited.add(key(ci,cj));
+      const start = new Room(mid,mid);
+      this.rooms[mid][mid] = start;
+      this.start = start;
+      const created = [start];
+      const coords = [{i:mid,j:mid}];
+      let attempts = 0;
+      while(created.length < CONFIG.roomsToMake && attempts < CONFIG.roomsToMake*20){
+        const baseIndex = Math.floor(rand()*coords.length);
+        const base = coords[baseIndex];
+        const baseRoom = this.rooms[base.i][base.j];
+        const options = DIRS.map(dir=>({dir,ni:base.i+dir.di,nj:base.j+dir.dj}))
+          .filter(opt=>opt.ni>=0 && opt.ni<this.gridN && opt.nj>=0 && opt.nj<this.gridN && !this.rooms[opt.ni][opt.nj]);
+        if(!options.length){ attempts++; continue; }
+        const choice = options[Math.floor(rand()*options.length)];
+        const newRoom = new Room(choice.ni, choice.nj);
+        this.rooms[choice.ni][choice.nj] = newRoom;
+        created.push(newRoom);
+        coords.push({i:choice.ni, j:choice.nj});
+        baseRoom.doors[choice.dir.key] = true;
+        newRoom.doors[choice.dir.opp] = true;
+        attempts = 0;
       }
-      // 连接门
+      this.allRooms = created;
+
+      this.current = this.start;
+      this.depth = 1;
+      this.bounds = {minI:mid, maxI:mid, minJ:mid, maxJ:mid};
+
+      // 指定 Boss 房 & 道具房
+      this.bossRoom = this.setupBossRoom(mid);
+      this.itemRooms = this.setupItemRooms(mid);
+
+      // 连接所有相邻房间的门，确保连通性
       for(let i=0;i<this.gridN;i++){
         for(let j=0;j<this.gridN;j++){
           const r = this.rooms[i][j]; if(!r) continue;
-          if(i>0 && this.rooms[i-1][j]) { r.doors.up=true; this.rooms[i-1][j].doors.down=true; }
-          if(i<this.gridN-1 && this.rooms[i+1][j]) { r.doors.down=true; this.rooms[i+1][j].doors.up=true; }
-          if(j>0 && this.rooms[i][j-1]) { r.doors.left=true; this.rooms[i][j-1].doors.right=true; }
-          if(j<this.gridN-1 && this.rooms[i][j+1]) { r.doors.right=true; this.rooms[i][j+1].doors.left=true; }
+          for(const dir of DIRS){
+            const ni = i + dir.di, nj = j + dir.dj;
+            if(ni<0 || nj<0 || ni>=this.gridN || nj>=this.gridN) continue;
+            if(this.rooms[ni][nj]){
+              r.doors[dir.key] = true;
+              this.rooms[ni][nj].doors[dir.opp] = true;
+            }
+          }
         }
       }
-      this.start = this.rooms[mid][mid];
-      this.current = this.start;
-      this.depth = 1;
-
-      // 指定 Boss 房
-      this.bossRoom = this.setupBossRoom(mid);
     }
 
     setupBossRoom(mid){
@@ -231,10 +300,10 @@
         }
       }
       if(!farthest) return null;
-      const dirs=[{di:-1,dj:0,key:'up',opp:'down'},{di:1,dj:0,key:'down',opp:'up'},{di:0,dj:-1,key:'left',opp:'right'},{di:0,dj:1,key:'right',opp:'left'}];
-      for(const dir of dirs){
-        const ni = clamp(farthest.i+dir.di,0,this.gridN-1);
-        const nj = clamp(farthest.j+dir.dj,0,this.gridN-1);
+      for(const dir of DIRS){
+        const ni = farthest.i+dir.di;
+        const nj = farthest.j+dir.dj;
+        if(ni<0 || nj<0 || ni>=this.gridN || nj>=this.gridN) continue;
         if(this.rooms[ni][nj]) continue;
         const bossRoom = new Room(ni,nj);
         bossRoom.isBoss=true;
@@ -242,6 +311,7 @@
         this.rooms[ni][nj]=bossRoom;
         farthest.doors[dir.key]=true;
         bossRoom.doors[dir.opp]=true;
+        this.allRooms.push(bossRoom);
         return bossRoom;
       }
       // 如果周围无空位，则直接把最远房间作为 Boss 房
@@ -249,8 +319,105 @@
       farthest.bossName = '哭泣塑像 · 胎衣蛹';
       return farthest;
     }
+
+    setupItemRooms(mid){
+      const items=[];
+      const available=[];
+      for(let i=0;i<this.gridN;i++){
+        for(let j=0;j<this.gridN;j++){
+          const r=this.rooms[i][j];
+          if(!r || r.isBoss || (i===mid && j===mid)) continue;
+          const dist = Math.abs(i-mid)+Math.abs(j-mid);
+          const options = DIRS.map(dir=>({dir,ni:i+dir.di,nj:j+dir.dj}))
+            .filter(opt=>opt.ni>=0 && opt.nj>=0 && opt.ni<this.gridN && opt.nj<this.gridN && !this.rooms[opt.ni][opt.nj]);
+          if(options.length){ available.push({room:r, options, dist}); }
+        }
+      }
+      const need = Math.max(1, CONFIG.itemRooms|0);
+      let placed = 0;
+      while(placed<need && available.length){
+        available.sort((a,b)=>b.dist-a.dist || rand()-0.5);
+        const choice = available.shift();
+        const target = choice.options[Math.floor(rand()*choice.options.length)];
+        const itemRoom = new Room(target.ni, target.nj);
+        itemRoom.isItemRoom = true;
+        itemRoom.cleared = true;
+        this.rooms[target.ni][target.nj] = itemRoom;
+        choice.room.doors[target.dir.key] = true;
+        itemRoom.doors[target.dir.opp] = true;
+        this.allRooms.push(itemRoom);
+        items.push(itemRoom);
+        placed++;
+        for(let k=available.length-1;k>=0;k--){
+          available[k].options = available[k].options.filter(opt=>!this.rooms[opt.ni][opt.nj]);
+          if(!available[k].options.length) available.splice(k,1);
+        }
+      }
+      if(placed===0){
+        // 如果无法扩展，则挑选一个非 Boss 房间直接转为道具房
+        for(let i=0;i<this.gridN;i++){
+          for(let j=0;j<this.gridN;j++){
+            const r=this.rooms[i][j];
+            if(!r || r.isBoss || (i===mid && j===mid)) continue;
+            r.isItemRoom = true;
+            r.cleared = true;
+            items.push(r);
+            placed=1;
+            break;
+          }
+          if(placed) break;
+        }
+      }
+      return items;
+    }
+
+    updateBounds(room){
+      if(!room) return;
+      this.bounds.minI = Math.min(this.bounds.minI, room.i);
+      this.bounds.maxI = Math.max(this.bounds.maxI, room.i);
+      this.bounds.minJ = Math.min(this.bounds.minJ, room.j);
+      this.bounds.maxJ = Math.max(this.bounds.maxJ, room.j);
+    }
+
+    revealRoom(room){
+      if(!room) return;
+      room.discovered = true;
+      this.updateBounds(room);
+    }
   }
   function key(i,j){return `${i},${j}`}
+
+  function rollItem(){
+    const total = ITEM_POOL.reduce((sum,item)=>sum+item.weight,0);
+    let pick = rand()*total;
+    for(const item of ITEM_POOL){
+      pick -= item.weight;
+      if(pick<=0) return {...item};
+    }
+    return {...ITEM_POOL[ITEM_POOL.length-1]};
+  }
+
+  function makeItemPickup(x,y,room){
+    return {
+      type:'item',
+      x:clamp(x,80,CONFIG.roomW-80),
+      y:clamp(y,90,CONFIG.roomH-90),
+      r:18,
+      item:room.itemData,
+      room
+    };
+  }
+
+  function pickupItem(pickup){
+    if(!pickup || !pickup.item) return;
+    const item = pickup.item;
+    if(typeof item.apply === 'function'){ item.apply(player); }
+    if(player && !player.items.includes(item.name)){ player.items.push(item.name); }
+    if(pickup.room){ pickup.room.itemClaimed = true; pickup.room.itemSpawned = false; }
+    itemPickupName = item.name;
+    itemPickupDesc = item.description || '';
+    itemPickupTimer = 3.2;
+  }
 
   // ======= 实体 =======
   class Player{
@@ -261,6 +428,7 @@
       this.fireCd = 0; this.fireInterval = CONFIG.player.fireCd;
       this.tearSpeed=CONFIG.player.tearSpeed; this.tearLife=CONFIG.player.tearLife;
       this.damage = 1;
+      this.items=[];
     }
     update(dt){
       const mv = {x:0,y:0};
@@ -498,6 +666,7 @@
   // ======= 运行时上下文 =======
   let dungeon, bullets=[], enemyProjectiles=[], player;
   let bossIntroTimer = 0, bossIntroText='';
+  let itemPickupTimer = 0, itemPickupName='', itemPickupDesc='';
   const pendingEnemySpawns = [];
 
   function startGame(){
@@ -505,10 +674,11 @@
     dungeon = new Dungeon();
     player = new Player(CONFIG.roomW/2, CONFIG.roomH/2);
     dungeon.current.visited=true;
+    dungeon.revealRoom(dungeon.current);
     dungeon.current.spawnEnemies(dungeon.depth);
     state = STATE.PLAY;
     lastTime = performance.now();
-    bullets.length=0; enemyProjectiles.length=0; bossIntroTimer=0;
+    bullets.length=0; enemyProjectiles.length=0; bossIntroTimer=0; itemPickupTimer=0; itemPickupName=''; itemPickupDesc='';
   }
 
   // ======= 门与换房 =======
@@ -526,28 +696,31 @@
     const r = dungeon.current;
     const doors = roomDoors(r);
     for(const d of doors){
-      if(!r.cleared) continue; // 清空才开门
+      const ni = r.i + (d.dir==='down') - (d.dir==='up');
+      const nj = r.j + (d.dir==='right') - (d.dir==='left');
+      const nr = dungeon.rooms[ni]?.[nj];
+      if(!nr) continue;
+      const doorUnlocked = r.cleared || r.isBoss || nr.isBoss;
+      if(!doorUnlocked) continue;
       if(rectCircleOverlap(d.x,d.y,d.w,d.h, player.x,player.y,player.r)){
-        // 传送到相邻房间
-        const ni = r.i + (d.dir==='down') - (d.dir==='up');
-        const nj = r.j + (d.dir==='right') - (d.dir==='left');
-        const nr = dungeon.rooms[ni]?.[nj];
-        if(nr){
-          dungeon.current = nr; nr.visited=true; dungeon.depth++;
-          // 入口位置
-          if(d.dir==='up'){ player.x=CONFIG.roomW/2; player.y=CONFIG.roomH-60; }
-          if(d.dir==='down'){ player.x=CONFIG.roomW/2; player.y=60; }
-          if(d.dir==='left'){ player.x=CONFIG.roomW-60; player.y=CONFIG.roomH/2; }
-          if(d.dir==='right'){ player.x=60; player.y=CONFIG.roomH/2; }
-          bullets.length=0; enemyProjectiles.length=0;
-          if(nr.isBoss && !nr.introPlayed){
-            bossIntroText = nr.bossName;
-            bossIntroTimer = 3.2;
-            nr.introPlayed = true;
-          }
-          if(!nr.cleared){ nr.spawnEnemies(dungeon.depth); }
-          break;
+        dungeon.current = nr;
+        if(!nr.visited){ dungeon.depth++; }
+        nr.visited = true;
+        dungeon.revealRoom(nr);
+        // 入口位置
+        if(d.dir==='up'){ player.x=CONFIG.roomW/2; player.y=CONFIG.roomH-60; }
+        if(d.dir==='down'){ player.x=CONFIG.roomW/2; player.y=60; }
+        if(d.dir==='left'){ player.x=CONFIG.roomW-60; player.y=CONFIG.roomH/2; }
+        if(d.dir==='right'){ player.x=60; player.y=CONFIG.roomH/2; }
+        bullets.length=0; enemyProjectiles.length=0;
+        if(nr.isBoss && !nr.introPlayed){
+          bossIntroText = nr.bossName;
+          bossIntroTimer = 3.2;
+          nr.introPlayed = true;
         }
+        if(nr.isItemRoom){ nr.ensureItem(); }
+        if(!nr.cleared || nr.isBoss){ nr.spawnEnemies(dungeon.depth); }
+        break;
       }
     }
   }
@@ -619,6 +792,9 @@
         if(p.type==='heart' && player.hp < player.maxHp){
           player.hp = Math.min(player.maxHp, player.hp + (p.heal || 1));
           picks.splice(i,1);
+        } else if(p.type==='item'){
+          pickupItem(p);
+          picks.splice(i,1);
         }
       }
     }
@@ -629,6 +805,8 @@
     // 更新 HUD
     renderHUD();
     bossIntroTimer = Math.max(0, bossIntroTimer - dt);
+    itemPickupTimer = Math.max(0, itemPickupTimer - dt);
+    if(itemPickupTimer<=0){ itemPickupName=''; itemPickupDesc=''; }
   }
 
   function renderHUD(){
@@ -647,10 +825,11 @@
       {label:'射程', value: range}
     ];
     HUDS.innerHTML = statItems.map(({label,value,unit})=>`<span>${label}：<strong>${value}</strong>${unit?`<small>${unit}</small>`:''}</span>`).join('');
+    const itemsText = player.items.length ? player.items.join('、') : '无';
     if(dungeon.current.isBoss && dungeon.current.bossEntity && !dungeon.current.bossEntity.dead){
-      HUDR.innerHTML = `层数：${dungeon.depth} / <span style="color:#ffb4c8">BOSS：${dungeon.current.bossEntity.name}</span>`;
+      HUDR.innerHTML = `<span style="display:flex;flex-direction:column;gap:2px;align-items:flex-end"><span>层数：${dungeon.depth} / <span style="color:#ffb4c8">BOSS：${dungeon.current.bossEntity.name}</span></span><span>道具：${itemsText}</span></span>`;
     } else {
-      HUDR.innerHTML = `层数：${dungeon.depth} / 已探索：${exploredRooms()} 间`;
+      HUDR.innerHTML = `<span style="display:flex;flex-direction:column;gap:2px;align-items:flex-end"><span>层数：${dungeon.depth} / 已探索：${exploredRooms()} 间</span><span>道具：${itemsText}</span></span>`;
     }
   }
   function exploredRooms(){
@@ -684,6 +863,8 @@
     // 小地图
     drawMiniMap();
 
+    drawItemPickupBanner();
+
     // 覆盖层显隐
     overlayMenu.classList.toggle('show', state===STATE.MENU);
     overlayPaused.classList.toggle('show', state===STATE.PAUSE);
@@ -708,12 +889,30 @@
   function drawDoors(){
     const r = dungeon.current; const doors = roomDoors(r);
     for(const d of doors){
+      const ni = r.i + (d.dir==='down') - (d.dir==='up');
+      const nj = r.j + (d.dir==='right') - (d.dir==='left');
+      const nr = dungeon.rooms[ni]?.[nj];
+      const leadsBoss = !!(nr && nr.isBoss && !nr.bossDefeated);
+      const leadsItem = !!(nr && nr.isItemRoom && !nr.itemClaimed);
+      const doorUnlocked = r.cleared || r.isBoss || (nr && nr.isBoss);
+      let frame = '#2a3142';
+      let fill = '#1e2330';
+      if(leadsBoss){
+        frame = doorUnlocked ? '#ff6b6b55' : '#2f1b28';
+        fill = doorUnlocked ? '#ff6b6b' : '#371822';
+      } else if(leadsItem){
+        frame = doorUnlocked ? '#facc1555' : '#3a3318';
+        fill = doorUnlocked ? '#facc15' : '#3b3414';
+      } else if(doorUnlocked){
+        frame = '#6ee7ff55';
+        fill = '#6ee7ff';
+      }
       ctx.save();
       // 门框
-      ctx.fillStyle = r.cleared ? '#6ee7ff55' : '#2a3142';
+      ctx.fillStyle = frame;
       ctx.fillRect(d.x-4,d.y-4,d.w+8,d.h+8);
       // 门
-      ctx.fillStyle = r.cleared ? '#6ee7ff' : '#1e2330';
+      ctx.fillStyle = fill;
       ctx.fillRect(d.x,d.y,d.w,d.h);
       ctx.restore();
     }
@@ -733,6 +932,63 @@
       ctx.fill();
       ctx.stroke();
       ctx.restore();
+    } else if(p.type==='item' && p.item){
+      const bob = Math.sin(performance.now()/480)*4;
+      ctx.save();
+      ctx.translate(p.x,p.y);
+      ctx.fillStyle = '#2a3146';
+      ctx.fillRect(-18,12,36,9);
+      ctx.fillStyle = '#39415c';
+      ctx.fillRect(-14,6,28,8);
+      ctx.translate(0, bob-6);
+      const id = p.item.id;
+      if(id==='onion'){
+        ctx.fillStyle = '#facc15';
+        ctx.strokeStyle = '#fff5';
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(0,-p.r*0.7);
+        ctx.bezierCurveTo(p.r*0.75,-p.r*0.3, p.r*0.55, p.r*0.45, 0, p.r*0.85);
+        ctx.bezierCurveTo(-p.r*0.55, p.r*0.45, -p.r*0.75, -p.r*0.3, 0, -p.r*0.7);
+        ctx.fill();
+        ctx.stroke();
+        ctx.strokeStyle = '#7c5b0f';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(0,-p.r*0.9);
+        ctx.lineTo(0,-p.r*1.2);
+        ctx.stroke();
+      } else if(id==='tar'){
+        const grad = ctx.createRadialGradient(0,-2,2,0,0,p.r*0.75);
+        grad.addColorStop(0,'#5f6cff');
+        grad.addColorStop(1,'#2d2f59');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.ellipse(0,0,p.r*0.9,p.r*0.7,0,0,Math.PI*2);
+        ctx.fill();
+      } else if(id==='sneaker'){
+        ctx.fillStyle = '#9ae6b4';
+        ctx.beginPath();
+        ctx.moveTo(-p.r*0.8, p.r*0.2);
+        ctx.quadraticCurveTo(-p.r*0.2, -p.r*0.7, p.r*0.8, -p.r*0.1);
+        ctx.lineTo(p.r*0.5, p.r*0.5);
+        ctx.quadraticCurveTo(-p.r*0.1, p.r*0.3, -p.r*0.8, p.r*0.2);
+        ctx.fill();
+        ctx.fillStyle='#2f855a';
+        ctx.fillRect(-p.r*0.2, -p.r*0.1, p.r*0.8, p.r*0.15);
+      } else {
+        ctx.fillStyle = '#b0c9ff';
+        ctx.beginPath();
+        ctx.arc(0,0,p.r*0.8,0,Math.PI*2);
+        ctx.fill();
+      }
+      ctx.restore();
+      ctx.save();
+      ctx.fillStyle = '#dde3ff';
+      ctx.font = '12px "HYWenHei", "PingFang SC", sans-serif';
+      ctx.textAlign='center';
+      ctx.fillText(p.item.name, p.x, p.y - 30);
+      ctx.restore();
     }
   }
   function drawPlayer(){
@@ -742,22 +998,30 @@
     if(player.ifr>0){ ctx.save(); ctx.globalAlpha = 0.5 + 0.5*Math.sin(performance.now()/60); ctx.strokeStyle='#fff'; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(player.x,player.y,player.r+3,0,Math.PI*2); ctx.stroke(); ctx.restore(); }
   }
   function drawMiniMap(){
-    const N = dungeon.gridN; const cell=12, pad=8; const left=16, top=16;
+    const cell=12, pad=8, left=16, top=16;
+    const discovered=[];
+    for(let i=0;i<dungeon.gridN;i++){
+      for(let j=0;j<dungeon.gridN;j++){
+        const r = dungeon.rooms[i][j];
+        if(r?.discovered) discovered.push(r);
+      }
+    }
+    if(!discovered.length) return;
+    const width = (dungeon.bounds.maxJ - dungeon.bounds.minJ + 1) * cell;
+    const height = (dungeon.bounds.maxI - dungeon.bounds.minI + 1) * cell;
     ctx.save();
     ctx.translate(left, top);
-    ctx.globalAlpha=0.9;
-    ctx.fillStyle='#141a25'; ctx.fillRect(-pad,-pad,N*cell+pad*2,N*cell+pad*2);
-    for(let i=0;i<N;i++){
-      for(let j=0;j<N;j++){
-        const r = dungeon.rooms[i][j];
-        const x = j*cell, y=i*cell;
-        if(!r){ ctx.fillStyle='#0b0f16'; }
-        else if(r===dungeon.current){ ctx.fillStyle='#6ee7ff'; }
-        else if(r.isBoss && !r.bossDefeated){ ctx.fillStyle='#ff6b6b'; }
-        else if(r.visited){ ctx.fillStyle='#2c3a54'; }
-        else { ctx.fillStyle='#182131'; }
-        ctx.fillRect(x,y,cell-1,cell-1);
-      }
+    ctx.globalAlpha = 0.92;
+    ctx.fillStyle = '#141a25';
+    ctx.fillRect(-pad,-pad,width+pad*2,height+pad*2);
+    for(const r of discovered){
+      const x = (r.j - dungeon.bounds.minJ) * cell;
+      const y = (r.i - dungeon.bounds.minI) * cell;
+      if(r===dungeon.current){ ctx.fillStyle='#6ee7ff'; }
+      else if(r.isBoss && !r.bossDefeated){ ctx.fillStyle='#ff6b6b'; }
+      else if(r.isItemRoom && !r.itemClaimed){ ctx.fillStyle='#facc15'; }
+      else { ctx.fillStyle='#2c3a54'; }
+      ctx.fillRect(x,y,cell-1,cell-1);
     }
     ctx.restore();
     if(bossIntroTimer>0){ drawBossIntro(); }
@@ -802,6 +1066,41 @@
     ctx.fillStyle='#ffd6e6';
     ctx.font='18px "HYWenHei", "PingFang SC", sans-serif';
     ctx.fillText('渗出的胎衣在地窖尽头凝聚成型……', CONFIG.roomW/2, CONFIG.roomH/2 + 28);
+    ctx.restore();
+  }
+
+  function drawItemPickupBanner(){
+    if(itemPickupTimer<=0 || !itemPickupName) return;
+    const baseText = `${itemPickupName} 入手！`;
+    const desc = itemPickupDesc;
+    ctx.save();
+    const lifeRatio = Math.min(1, itemPickupTimer / 1.2);
+    ctx.globalAlpha = 0.85 + 0.15*lifeRatio;
+    ctx.textAlign='center';
+    const mainFont='20px "HYWenHei", "PingFang SC", sans-serif';
+    const subFont='14px "HYWenHei", "PingFang SC", sans-serif';
+    ctx.font = mainFont;
+    const mainWidth = ctx.measureText(baseText).width;
+    ctx.font = subFont;
+    const subWidth = desc ? ctx.measureText(desc).width : 0;
+    const paddingX = 22;
+    const w = Math.max(mainWidth, subWidth) + paddingX*2;
+    const h = desc ? 70 : 50;
+    const x = CONFIG.roomW/2 - w/2;
+    const y = CONFIG.roomH - h - 36;
+    ctx.fillStyle = '#0b101dcc';
+    ctx.fillRect(x, y, w, h);
+    ctx.strokeStyle = '#2f3755';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(x+1, y+1, w-2, h-2);
+    ctx.font = mainFont;
+    ctx.fillStyle = '#facc15';
+    ctx.fillText(baseText, CONFIG.roomW/2, y + 28);
+    if(desc){
+      ctx.font = subFont;
+      ctx.fillStyle = '#d6dcff';
+      ctx.fillText(desc, CONFIG.roomW/2, y + 52);
+    }
     ctx.restore();
   }
 


### PR DESCRIPTION
## Summary
- rework dungeon generation to produce irregular layouts, reveal only explored rooms on the minimap, and unlock boss doors once discovered
- add dedicated item rooms that spawn weighted items, including the new 洋葱 pickup that grants +0.75 tears per second
- update HUD, door visuals, and pickups to reflect the new item system and show contextual notifications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0a5ecf3b8832c913a516a0fc8695b