### PR TITLE
Fix startup errors preventing game from running

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,6 +783,8 @@
   const footerTextNode = document.getElementById('footer-text');
   const cheatToggle = document.getElementById('cheat-toggle');
   const cheatPanelNode = document.getElementById('cheat-panel');
+  const virtualKbToggle = document.getElementById('vk-toggle');
+  const virtualKbPanel = document.getElementById('virtual-kb');
   const cheatInputs = {
     hp: document.getElementById('cheat-hp'),
     maxHp: document.getElementById('cheat-maxhp'),
@@ -865,7 +867,7 @@
     if(pauseDescNode) pauseDescNode.innerHTML = t('ui.pauseDesc');
     if(gameoverTitleNode) gameoverTitleNode.textContent = t('ui.gameoverTitle');
     if(gameoverDescNode) gameoverDescNode.innerHTML = t('ui.gameoverDesc');
-    if(vkToggle) vkToggle.textContent = t('ui.virtualKeyboard');
+    if(virtualKbToggle) virtualKbToggle.textContent = t('ui.virtualKeyboard');
     if(cheatToggle) cheatToggle.textContent = t('ui.cheatToggle');
     if(cheatStatusTitle) cheatStatusTitle.textContent = t('ui.cheat.status');
     if(cheatResourcesTitle) cheatResourcesTitle.textContent = t('ui.cheat.resources');
@@ -1357,8 +1359,6 @@
   });
   window.addEventListener('keyup', (e)=> processKeyUp(e.code));
 
-  const virtualKbToggle = document.getElementById('vk-toggle');
-  const virtualKbPanel = document.getElementById('virtual-kb');
   const virtualKeyboard = createVirtualKeyboard({
     panel: virtualKbPanel,
     toggle: virtualKbToggle,
@@ -3730,6 +3730,10 @@
 
   // ======= 渲染 =======
   function draw(){
+    if(!dungeon || !dungeon.current){
+      ctx.clearRect(0,0,CONFIG.roomW, CONFIG.roomH);
+      return;
+    }
     // 背景
     ctx.clearRect(0,0,CONFIG.roomW, CONFIG.roomH);
     drawRoomBackdrop();


### PR DESCRIPTION
## Summary
- correctly query the virtual keyboard controls up front and use the right variable inside the language application routine to avoid a ReferenceError on load
- guard the render loop against running before the dungeon is initialized so the game can sit on the menu without crashing

## Testing
- python -m http.server 8000 (manual check via curl)
- curl -I http://127.0.0.1:8000/index.html


------
https://chatgpt.com/codex/tasks/task_e_68d1056f5cf4832cb583df20908f30c3