### PR TITLE
Improve player acceleration responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,9 +186,11 @@
       fireCd: 360,
       tearSpeed: 230,
       tearLife: 0.65,
-      accelTime: 0.6,      // 0 → 正常移动速度所需时间（秒）
+      accelTime: 0.42,     // 0 → 正常移动速度所需时间（秒）
       decelTime: 0.6,      // 正常移动速度 → 0 所需时间（秒）
       maxSpeedScale: 1.1, // 允许的速度上限倍率，给予一点惯性裕度
+      startBoost: 0.58,    // 刚起步时给一个轻微的速度助推，减少“起步肉感”
+      startBoostThreshold: 0.42, // 低于该比例速度时触发起步助推
     }, // fireCd 毫秒
     enemy: {
       baseHP: 2,
@@ -1699,6 +1701,8 @@
       this.accelTime = CONFIG.player.accelTime ?? 0.6;
       this.decelTime = CONFIG.player.decelTime ?? 0.6;
       this.maxSpeedScale = CONFIG.player.maxSpeedScale ?? 1.1;
+      this.startBoost = clamp(CONFIG.player.startBoost ?? 0, 0, 1);
+      this.startBoostThreshold = clamp(CONFIG.player.startBoostThreshold ?? this.startBoost ?? 0, 0, 1);
     }
     update(dt){
       this.bombCooldown = Math.max(0, this.bombCooldown - dt);
@@ -1721,6 +1725,15 @@
         const targetSpeed = this.speed;
         const targetX = nx * targetSpeed;
         const targetY = ny * targetSpeed;
+        const currentSpeed = Math.hypot(this.vel.x, this.vel.y);
+        if(this.startBoost>0){
+          const threshold = targetSpeed * this.startBoostThreshold;
+          if(currentSpeed < threshold){
+            const boostSpeed = targetSpeed * this.startBoost;
+            this.vel.x = nx * boostSpeed;
+            this.vel.y = ny * boostSpeed;
+          }
+        }
         const dx = targetX - this.vel.x;
         const dy = targetY - this.vel.y;
         const delta = Math.hypot(dx, dy);


### PR DESCRIPTION
## Summary
- reduce the base acceleration time so the player reaches top speed more quickly
- add a configurable start boost to give the player an initial push when movement begins
- store the new boost parameters on the player entity and apply them during acceleration updates

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d1216d6294832c8d2cfa1cebc7fcc9