### PR TITLE
Add life-trade pickups and Brimstone attack mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,17 @@
       dropChanceOnItemPickup: 0.35,
       shopCardChance: 0.22,
     },
+    lifeTrade: {
+      spawnChance: 0.25,
+      defaultCost: 2,
+      spawnPosition: { x: 120, y: 150 },
+    },
+    brimstone: {
+      tickFrames: 15,
+      beamDuration: 2,
+      damageScale: 0.7,
+      widthGrowth: 1.5,
+    },
     progression: {
       enemyHp: 1.2,
       enemySpeed: 1.1,
@@ -311,12 +322,26 @@
     const a = clamp(Number(alpha) || 0, 0, 1);
     return `rgba(${rgb.r},${rgb.g},${rgb.b},${a})`;
   }
+  function mixHexColor(colorA, colorB, t){
+    const from = hexToRgb(colorA);
+    const to = hexToRgb(colorB);
+    if(!from || !to){
+      return t<0.5 ? colorA : colorB;
+    }
+    const mix = clamp(Number(t) || 0, 0, 1);
+    const lerp = (a,b)=>Math.round(a + (b-a)*mix);
+    const toHex = (c)=>c.toString(16).padStart(2,'0');
+    return `#${toHex(lerp(from.r,to.r))}${toHex(lerp(from.g,to.g))}${toHex(lerp(from.b,to.b))}`;
+  }
   function adjustFireRate(player, delta){
     if(!player) return;
     const currentRate = player.fireInterval>0 ? 1000/player.fireInterval : 0;
     const newRate = Math.max(0.1, currentRate + delta);
     player.fireInterval = 1000 / newRate;
     player.fireCd = Math.min(player.fireCd, player.fireInterval);
+    if(typeof player.updateBrimstoneChargeMetrics === 'function'){
+      player.updateBrimstoneChargeMetrics();
+    }
   }
   const DIRS = [
     {di:-1,dj:0,key:'up',opp:'down'},
@@ -685,6 +710,58 @@
       apply(player){ ITEM_REF_MAGIC_BULLET?.apply?.(player); }
     }
   ];
+  const LIFE_TRADE_EXTRA_POOL = [
+    {
+      slug:'brimstone',
+      name:'硫磺火',
+      weight:2,
+      description:'被动：蓄力释放贯穿障碍的血色激光。蓄力时间随射速缩短，束宽随拾取次数递增。每 15 帧造成 0.7 倍攻击伤害，持续 2 秒。拾取后仅保留 1 点生命上限。',
+      lifeTradeCost:{type:'set-to-one'},
+      apply(player){
+        if(!player) return;
+        if(typeof player.ensureBrimstoneMode === 'function'){
+          player.ensureBrimstoneMode();
+        } else {
+          player.attackMode = 'brimstone';
+          player.brimstoneStacks = Math.max(1, (player.brimstoneStacks||0) + 1);
+        }
+        if(typeof player.setMaxHpToSingle === 'function'){
+          player.setMaxHpToSingle();
+        } else {
+          player.maxHp = 1;
+          player.hp = Math.min(player.hp, 1);
+          player.recalculateDamage?.();
+        }
+      }
+    }
+  ];
+  function buildLifeTradePool(){
+    const combined = [];
+    const defaultCost = Math.max(1, Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    const addPool = (pool)=>{
+      if(!Array.isArray(pool)) return;
+      for(const item of pool){
+        if(!item) continue;
+        const clone = {...item};
+        if(clone.lifeTradeCost){
+          if(clone.lifeTradeCost.type==='flat' && !Number.isFinite(clone.lifeTradeCost.amount)){
+            clone.lifeTradeCost = {...clone.lifeTradeCost, amount: defaultCost};
+          } else {
+            clone.lifeTradeCost = {...clone.lifeTradeCost};
+          }
+        } else {
+          clone.lifeTradeCost = {type:'flat', amount: defaultCost};
+        }
+        combined.push(clone);
+      }
+    };
+    addPool(ITEM_POOL);
+    addPool(SHOP_ITEM_POOL);
+    addPool(BOSS_ITEM_POOL);
+    addPool(LIFE_TRADE_EXTRA_POOL);
+    return combined;
+  }
+  const LIFE_TRADE_POOL = buildLifeTradePool();
   const CARD_POOL = [
     {
       slug:'seer-card',
@@ -802,7 +879,7 @@
     }
   ];
   const ITEM_ID_REGISTRY = (()=>{
-    const pools = [ITEM_POOL, SHOP_ITEM_POOL, BOSS_ITEM_POOL];
+    const pools = [ITEM_POOL, SHOP_ITEM_POOL, BOSS_ITEM_POOL, LIFE_TRADE_EXTRA_POOL];
     const byKey = new Map();
     const byId = new Map();
     let nextId = 1;
@@ -1004,6 +1081,9 @@
     if(Number.isFinite(fireRate) && fireRate>0){
       player.fireInterval = 1000 / fireRate;
       player.fireCd = Math.min(player.fireCd, player.fireInterval);
+      if(typeof player.updateBrimstoneChargeMetrics === 'function'){
+        player.updateBrimstoneChargeMetrics();
+      }
     }
     if(Number.isFinite(tearSpeed) && tearSpeed>0){ player.tearSpeed = tearSpeed; }
     if(player.hp>player.maxHp) player.hp = player.maxHp;
@@ -1696,6 +1776,7 @@
       this.bossRoom = this.setupBossRoom(mid);
       this.itemRooms = this.setupItemRooms(mid);
       this.shopRoom = this.setupShopRoom(mid);
+      this.setupLifeTradePickup();
 
       // 连接所有相邻房间的门，确保连通性
       for(let i=0;i<this.gridN;i++){
@@ -1711,6 +1792,20 @@
           }
         }
       }
+    }
+
+    setupLifeTradePickup(){
+      if(!this.start || this.lifeTradePrepared) return;
+      const cfg = CONFIG.lifeTrade || {};
+      const chance = Math.max(0, Math.min(1, cfg.spawnChance ?? 0.25));
+      if(rand() >= chance) return;
+      const item = rollLifeTradeItem();
+      if(!item) return;
+      const pos = cfg.spawnPosition || {x: 120, y: 150};
+      const pickup = makeLifeTradePickup(pos.x, pos.y, item, {room:this.start});
+      if(!pickup) return;
+      this.start.pickups.push(pickup);
+      this.lifeTradePrepared = true;
     }
 
     setupBossRoom(mid){
@@ -1968,6 +2063,9 @@
   function rollBossItem(){
     return weightedRoll(BOSS_ITEM_POOL);
   }
+  function rollLifeTradeItem(){
+    return weightedRoll(LIFE_TRADE_POOL);
+  }
 
   function makeItemPickup(x,y,room){
     return {
@@ -1981,6 +2079,83 @@
       vy:0,
       solid:false
     };
+  }
+  function normalizeLifeTradeCost(cost){
+    const fallback = Math.max(1, Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    if(!cost){
+      return {type:'flat', amount: fallback};
+    }
+    if(cost.type === 'set-to-one'){
+      return {type:'set-to-one'};
+    }
+    const amount = Math.max(1, Math.floor(Number.isFinite(cost.amount) ? cost.amount : fallback));
+    return {type:'flat', amount};
+  }
+  function formatLifeTradeCost(cost){
+    if(!cost) return '献祭未知代价';
+    if(cost.type === 'set-to-one') return '献祭至 1 心';
+    const amount = Math.max(1, cost.amount ?? Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    return `献祭 ${amount} 点上限`;
+  }
+  function makeLifeTradePickup(x,y,item, options={}){
+    if(!item) return null;
+    const baseCost = options.costConfig || item.lifeTradeCost;
+    const cost = normalizeLifeTradeCost(baseCost);
+    const px = clamp(options.x ?? x, 80, CONFIG.roomW-80);
+    const py = clamp(options.y ?? y, 90, CONFIG.roomH-90);
+    const clone = {...item};
+    clone.lifeTradeCost = normalizeLifeTradeCost(clone.lifeTradeCost || cost);
+    return {
+      type:'life-trade',
+      x:px,
+      y:py,
+      r: options.radius || 18,
+      item: clone,
+      room: options.room || null,
+      costConfig: cost,
+      costLabel: formatLifeTradeCost(cost),
+      solid:false,
+      spawnGrace:0,
+      label: options.label || null,
+    };
+  }
+  function canAffordLifeTrade(playerInstance, cost){
+    if(!playerInstance || !cost) return false;
+    if(cost.type === 'set-to-one'){
+      return playerInstance.maxHp >= 1;
+    }
+    const amount = Math.max(1, cost.amount ?? Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    return playerInstance.maxHp - amount >= 1;
+  }
+  function applyLifeTradeCost(playerInstance, cost){
+    if(!playerInstance || !cost) return false;
+    if(cost.type === 'set-to-one'){
+      if(typeof playerInstance.setMaxHpToSingle === 'function'){
+        playerInstance.setMaxHpToSingle();
+      } else {
+        playerInstance.maxHp = Math.max(1, Math.floor(playerInstance.maxHp));
+        playerInstance.hp = Math.min(playerInstance.hp, 1);
+        playerInstance.maxHp = 1;
+        playerInstance.recalculateDamage?.();
+      }
+      return true;
+    }
+    const amount = Math.max(1, cost.amount ?? Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    if(!canAffordLifeTrade(playerInstance, {type:'flat', amount})) return false;
+    if(typeof playerInstance.adjustMaxHp === 'function'){
+      playerInstance.adjustMaxHp(-amount);
+    } else {
+      playerInstance.maxHp = Math.max(1, playerInstance.maxHp - amount);
+      if(playerInstance.hp > playerInstance.maxHp){ playerInstance.hp = playerInstance.maxHp; }
+      playerInstance.recalculateDamage?.();
+    }
+    return true;
+  }
+  function describeLifeTradeRequirement(cost){
+    if(!cost) return '需要更多生命上限。';
+    if(cost.type === 'set-to-one') return '需要至少 1 点生命上限。';
+    const amount = Math.max(1, cost.amount ?? Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
+    return `需要至少 ${amount + 1} 点生命上限。`;
   }
   function makeResourcePickup(type,x,y,amount){
     return {
@@ -2056,6 +2231,28 @@
     runtime.itemPickupDesc = item.description || '';
     runtime.itemPickupTimer = 3.2;
     maybeSpawnCardDrop(pickup.room || dungeon?.current, {x: pickup.x, y: pickup.y});
+  }
+  function attemptLifeTradePickup(pickup){
+    if(!pickup || !pickup.item) return false;
+    const cost = normalizeLifeTradeCost(pickup.costConfig || pickup.item.lifeTradeCost);
+    if(!canAffordLifeTrade(player, cost)){
+      if(runtime.itemPickupTimer<=0){
+        runtime.itemPickupName = '血量不足';
+        runtime.itemPickupDesc = describeLifeTradeRequirement(cost);
+        runtime.itemPickupTimer = 1.6;
+      }
+      return false;
+    }
+    if(!applyLifeTradeCost(player, cost)) return false;
+    const item = pickup.item;
+    if(typeof item.apply === 'function'){ item.apply(player); }
+    if(player && !player.items.includes(item.name)){ player.items.push(item.name); }
+    registerItemDiscovery(item);
+    runtime.itemPickupName = item.name;
+    runtime.itemPickupDesc = item.description || '';
+    runtime.itemPickupTimer = 3.2;
+    maybeSpawnCardDrop(pickup.room || dungeon?.current, {x: pickup.x, y: pickup.y});
+    return true;
   }
   function grantResource(type, amount){
     if(!player) return 0;
@@ -2217,6 +2414,78 @@
       }
     }
   }
+  function endBeam(beam){
+    if(!beam) return;
+    const idx = runtime.beams ? runtime.beams.indexOf(beam) : -1;
+    if(idx>=0){ runtime.beams.splice(idx,1); }
+    if(beam.owner && beam.owner.brimstoneBeam === beam){
+      beam.owner.brimstoneBeam = null;
+      beam.owner.brimstoneFiring = false;
+      beam.owner.brimstoneBeamTimer = 0;
+    }
+  }
+  function computeBeamGeometry(beam){
+    const owner = beam?.owner;
+    if(!owner) return null;
+    const dir = beam.dir || {x:1,y:0};
+    const len = Math.hypot(dir.x, dir.y) || 1;
+    const nx = dir.x / len;
+    const ny = dir.y / len;
+    const startOffset = owner.r + (beam.startOffset ?? owner.r*0.2);
+    const startX = owner.x + nx * startOffset;
+    const startY = owner.y + ny * startOffset;
+    const minX = 20, maxX = CONFIG.roomW - 20, minY = 20, maxY = CONFIG.roomH - 20;
+    let maxT = Infinity;
+    if(nx > 0){ maxT = Math.min(maxT, (maxX - startX) / nx); }
+    else if(nx < 0){ maxT = Math.min(maxT, (minX - startX) / nx); }
+    if(ny > 0){ maxT = Math.min(maxT, (maxY - startY) / ny); }
+    else if(ny < 0){ maxT = Math.min(maxT, (minY - startY) / ny); }
+    if(!Number.isFinite(maxT) || maxT < 0){ maxT = 0; }
+    const endX = startX + nx * maxT;
+    const endY = startY + ny * maxT;
+    const length = Math.hypot(endX - startX, endY - startY);
+    return {startX, startY, endX, endY, length, nx, ny};
+  }
+  function applyBeamDamage(beam){
+    const room = dungeon?.current;
+    if(!room) return;
+    const geom = computeBeamGeometry(beam);
+    if(!geom || geom.length<=0) return;
+    const enemies = room.enemies;
+    const owner = beam.owner;
+    const width = owner?.getBrimstoneWidth?.() ?? beam.width ?? 24;
+    const half = Math.max(4, width * 0.5);
+    const damageScale = beam.damageScale ?? (CONFIG.brimstone?.damageScale ?? 0.7);
+    const damageValue = Math.max(0, (owner?.damage ?? 1) * damageScale);
+    for(const enemy of enemies){
+      if(enemy.dead) continue;
+      const result = pointSegmentDistance(enemy.x, enemy.y, geom.startX, geom.startY, geom.endX, geom.endY);
+      const threshold = half + (enemy.r || 12);
+      if(result.distance <= threshold){
+        if(enemy.damage(damageValue)){ handleEnemyDeath(enemy, room); }
+      }
+    }
+  }
+  function updateBeams(dt){
+    const beams = runtime.beams;
+    if(!Array.isArray(beams) || !beams.length) return;
+    const tickFrames = Math.max(1, CONFIG.brimstone?.tickFrames ?? 15);
+    const tickInterval = tickFrames / 60;
+    for(let i=beams.length-1;i>=0;i--){
+      const beam = beams[i];
+      if(!beam){ beams.splice(i,1); continue; }
+      beam.timer -= dt;
+      beam.tickTimer = (beam.tickTimer ?? 0) - dt;
+      if(beam.timer <= 0 || !beam.owner){
+        endBeam(beam);
+        continue;
+      }
+      if(beam.tickTimer <= 0){
+        beam.tickTimer += beam.tickInterval ?? tickInterval;
+        applyBeamDamage(beam);
+      }
+    }
+  }
   function keepBombInBounds(bomb){
     const margin = bomb.r + 24;
     const marginY = bomb.r + 24;
@@ -2288,6 +2557,17 @@
       this.accelTime = CONFIG.player.accelTime ?? 0.6;
       this.decelTime = CONFIG.player.decelTime ?? 0.6;
       this.maxSpeedScale = CONFIG.player.maxSpeedScale ?? 1.1;
+      this.attackMode = 'tears';
+      this.brimstoneStacks = 0;
+      this.brimstoneCharging = false;
+      this.brimstoneCharged = false;
+      this.brimstoneCharge = 0;
+      this.brimstoneChargeTime = Math.max(0.2, (this.fireInterval || CONFIG.player.fireCd)/1000);
+      this.brimstoneAim = {x:0, y:-1};
+      this.brimstoneBeam = null;
+      this.brimstoneFiring = false;
+      this.brimstoneBeamTimer = 0;
+      this.updateBrimstoneChargeMetrics();
     }
     update(dt){
       this.bombCooldown = Math.max(0, this.bombCooldown - dt);
@@ -2367,17 +2647,11 @@
       this.fireCd = Math.max(0, this.fireCd - dt*1000);
 
       // 射击（方向键）
-      let sx=0, sy=0;
-      if(keys.has('ArrowUp')) sy -= 1;
-      if(keys.has('ArrowDown')) sy += 1;
-      if(keys.has('ArrowLeft')) sx -= 1;
-      if(keys.has('ArrowRight')) sx += 1;
-      let shotDir = null;
-      if((sx||sy) && this.fireCd<=0){
-        const l = Math.hypot(sx,sy)||1;
-        shotDir = {x: sx/l, y: sy/l};
-        this.fireCd = this.fireInterval;
-      }
+      let shotX=0, shotY=0;
+      if(keys.has('ArrowUp')) shotY -= 1;
+      if(keys.has('ArrowDown')) shotY += 1;
+      if(keys.has('ArrowLeft')) shotX -= 1;
+      if(keys.has('ArrowRight')) shotX += 1;
       const preResolveX = this.x;
       const preResolveY = this.y;
       resolveEntityObstacles(this);
@@ -2403,66 +2677,77 @@
       this.lastDisplacement.y = dy;
       this.lastVelocity.x = lvx;
       this.lastVelocity.y = lvy;
-      if(shotDir){
-        const combatCfg = CONFIG.combat || {};
-        const carry = combatCfg.shotCarry ?? combatCfg.shotInertia ?? 0;
-        const forwardScale = combatCfg.shotForwardBoost ?? 0;
-        const reverseScale = combatCfg.shotReverseBoost ?? 0;
-        const lateralScale = combatCfg.shotLateralInfluence ?? 0;
-        const forwardSpeed = lvx * shotDir.x + lvy * shotDir.y;
-        let dirX = shotDir.x;
-        let dirY = shotDir.y;
-        if(lateralScale>0){
-          const totalSpeed = Math.hypot(lvx, lvy);
-          const speedRef = maxSpeed>0 ? maxSpeed : Math.max(totalSpeed, 1);
-          if(speedRef>1e-5 && totalSpeed>1e-4){
-            const lateral = lvx * (-shotDir.y) + lvy * shotDir.x;
-            if(Math.abs(lateral)>1e-4){
-              const lateralNormRaw = clamp(Math.abs(lateral) / speedRef, 0, 1);
-              const curvePower = clamp(combatCfg.shotLateralCurve ?? 1, 0.1, 6);
-              const curved = Math.pow(lateralNormRaw, curvePower);
-              const smooth = curved * curved * (3 - 2 * curved);
-              const speedNorm = clamp(totalSpeed / speedRef, 0, 1);
-              const blend = smooth * (0.6 + 0.4 * Math.pow(speedNorm, 1.35));
-              const angleBaseDeg = combatCfg.shotLateralAngle ?? 28;
-              const angle = Math.sign(lateral) * (angleBaseDeg * Math.PI / 180) * lateralScale * blend;
-              if(Math.abs(angle)>1e-4){
-                const cos = Math.cos(angle);
-                const sin = Math.sin(angle);
-                const ndx = dirX * cos - dirY * sin;
-                const ndy = dirX * sin + dirY * cos;
-                dirX = ndx;
-                dirY = ndy;
-                const dlen = Math.hypot(dirX, dirY) || 1;
-                dirX /= dlen;
-                dirY /= dlen;
+      const shotPressed = shotX || shotY;
+      if(this.attackMode === 'brimstone'){
+        this.handleBrimstoneAttack(dt, shotX, shotY, lvx, lvy, maxSpeed);
+      } else {
+        let shotDir = null;
+        if(shotPressed && this.fireCd<=0){
+          const l = Math.hypot(shotX,shotY)||1;
+          shotDir = {x: shotX/l, y: shotY/l};
+          this.fireCd = this.fireInterval;
+        }
+        if(shotDir){
+          const combatCfg = CONFIG.combat || {};
+          const carry = combatCfg.shotCarry ?? combatCfg.shotInertia ?? 0;
+          const forwardScale = combatCfg.shotForwardBoost ?? 0;
+          const reverseScale = combatCfg.shotReverseBoost ?? 0;
+          const lateralScale = combatCfg.shotLateralInfluence ?? 0;
+          const forwardSpeed = lvx * shotDir.x + lvy * shotDir.y;
+          let dirX = shotDir.x;
+          let dirY = shotDir.y;
+          if(lateralScale>0){
+            const totalSpeed = Math.hypot(lvx, lvy);
+            const speedRef = maxSpeed>0 ? maxSpeed : Math.max(totalSpeed, 1);
+            if(speedRef>1e-5 && totalSpeed>1e-4){
+              const lateral = lvx * (-shotDir.y) + lvy * shotDir.x;
+              if(Math.abs(lateral)>1e-4){
+                const lateralNormRaw = clamp(Math.abs(lateral) / speedRef, 0, 1);
+                const curvePower = clamp(combatCfg.shotLateralCurve ?? 1, 0.1, 6);
+                const curved = Math.pow(lateralNormRaw, curvePower);
+                const smooth = curved * curved * (3 - 2 * curved);
+                const speedNorm = clamp(totalSpeed / speedRef, 0, 1);
+                const blend = smooth * (0.6 + 0.4 * Math.pow(speedNorm, 1.35));
+                const angleBaseDeg = combatCfg.shotLateralAngle ?? 28;
+                const angle = Math.sign(lateral) * (angleBaseDeg * Math.PI / 180) * lateralScale * blend;
+                if(Math.abs(angle)>1e-4){
+                  const cos = Math.cos(angle);
+                  const sin = Math.sin(angle);
+                  const ndx = dirX * cos - dirY * sin;
+                  const ndy = dirX * sin + dirY * cos;
+                  dirX = ndx;
+                  dirY = ndy;
+                  const dlen = Math.hypot(dirX, dirY) || 1;
+                  dirX /= dlen;
+                  dirY /= dlen;
+                }
               }
             }
           }
+          let baseSpeed = this.tearSpeed;
+          if(forwardScale!==0 && forwardSpeed>1e-4){
+            const boost = forwardSpeed * forwardScale;
+            baseSpeed = Math.max(40, baseSpeed + boost);
+          } else if(forwardSpeed < -1e-4 && reverseScale>0){
+            const oppose = -forwardSpeed;
+            const speedRef = maxSpeed>0 ? maxSpeed : Math.max(Math.hypot(lvx, lvy), 1);
+            const norm = speedRef>0 ? clamp(oppose / speedRef, 0, 1.4) : 0;
+            const eased = norm * (0.55 + 0.45 * norm);
+            const boost = oppose * reverseScale * (0.5 + 0.5 * eased);
+            baseSpeed = Math.max(40, baseSpeed + boost);
+          }
+          let vx = dirX * baseSpeed;
+          let vy = dirY * baseSpeed;
+          if(carry!==0){
+            vx += lvx * carry;
+            vy += lvy * carry;
+          }
+          runtime.bullets.push(new Bullet(this.x, this.y, vx, vy, this.tearLife, this.damage, {
+            pierce: this.canPierceObstacles,
+            homing: this.homingTears,
+            homingStrength: this.homingStrength
+          }));
         }
-        let baseSpeed = this.tearSpeed;
-        if(forwardScale!==0 && forwardSpeed>1e-4){
-          const boost = forwardSpeed * forwardScale;
-          baseSpeed = Math.max(40, baseSpeed + boost);
-        } else if(forwardSpeed < -1e-4 && reverseScale>0){
-          const oppose = -forwardSpeed;
-          const speedRef = maxSpeed>0 ? maxSpeed : Math.max(Math.hypot(lvx, lvy), 1);
-          const norm = speedRef>0 ? clamp(oppose / speedRef, 0, 1.4) : 0;
-          const eased = norm * (0.55 + 0.45 * norm);
-          const boost = oppose * reverseScale * (0.5 + 0.5 * eased);
-          baseSpeed = Math.max(40, baseSpeed + boost);
-        }
-        let vx = dirX * baseSpeed;
-        let vy = dirY * baseSpeed;
-        if(carry!==0){
-          vx += lvx * carry;
-          vy += lvy * carry;
-        }
-        runtime.bullets.push(new Bullet(this.x, this.y, vx, vy, this.tearLife, this.damage, {
-          pierce: this.canPierceObstacles,
-          homing: this.homingTears,
-          homingStrength: this.homingStrength
-        }));
       }
       this.recalculateDamage();
     }
@@ -2506,6 +2791,107 @@
       }
       this.recalculateDamage();
     }
+    updateBrimstoneChargeMetrics(){
+      const interval = Number.isFinite(this.fireInterval) ? this.fireInterval : (CONFIG.player.fireCd || 360);
+      this.brimstoneChargeTime = Math.max(0.15, interval / 1000);
+    }
+    ensureBrimstoneMode(){
+      if(this.attackMode !== 'brimstone'){
+        this.attackMode = 'brimstone';
+        this.brimstoneStacks = 0;
+      }
+      this.brimstoneStacks = Math.max(0, (this.brimstoneStacks || 0)) + 1;
+      this.brimstoneCharging = false;
+      this.brimstoneCharged = false;
+      this.brimstoneCharge = 0;
+      this.brimstoneAim = this.brimstoneAim || {x:0, y:-1};
+      this.interruptBrimstoneBeam();
+      this.updateBrimstoneChargeMetrics();
+    }
+    setMaxHpToSingle(){
+      this.maxHp = 1;
+      if(this.hp > this.maxHp){ this.hp = this.maxHp; }
+      this.recalculateDamage();
+    }
+    getBrimstoneWidth(){
+      const base = this.r * 2 * 1.5;
+      const growth = CONFIG.brimstone?.widthGrowth ?? 1.5;
+      const stacks = Math.max(1, this.brimstoneStacks || 1);
+      return base * Math.pow(growth, stacks - 1);
+    }
+    getBrimstoneChargeRatio(){
+      if(this.brimstoneBeam){
+        return 1;
+      }
+      const denom = Math.max(0.0001, this.brimstoneChargeTime || 0.2);
+      const ratio = clamp(this.brimstoneCharge / denom, 0, 1);
+      return this.brimstoneCharged ? 1 : ratio;
+    }
+    interruptBrimstoneBeam(){
+      if(this.brimstoneBeam){ endBeam(this.brimstoneBeam); }
+    }
+    handleBrimstoneAttack(dt, sx, sy, lvx, lvy, maxSpeed){
+      const pressed = !!(sx || sy);
+      if(this.brimstoneBeam){
+        this.brimstoneBeamTimer = Math.max(0, (this.brimstoneBeamTimer || 0) - dt);
+        if(pressed){
+          this.interruptBrimstoneBeam();
+        }
+      }
+      if(this.brimstoneBeam){
+        return;
+      }
+      if(pressed){
+        const len = Math.hypot(sx, sy) || 1;
+        this.brimstoneAim.x = sx / len;
+        this.brimstoneAim.y = sy / len;
+        if(!this.brimstoneCharging){
+          this.brimstoneCharging = true;
+          this.brimstoneCharge = 0;
+          this.brimstoneCharged = false;
+        }
+        this.brimstoneCharge += dt;
+        if(this.brimstoneCharge >= this.brimstoneChargeTime){
+          this.brimstoneCharge = this.brimstoneChargeTime;
+          this.brimstoneCharged = true;
+        }
+      } else {
+        if(this.brimstoneCharging){
+          if(this.brimstoneCharged){
+            this.fireBrimstoneBeam();
+          }
+          this.brimstoneCharging = false;
+          this.brimstoneCharge = 0;
+          this.brimstoneCharged = false;
+        }
+      }
+    }
+    fireBrimstoneBeam(){
+      const aim = this.brimstoneAim || {x:0, y:-1};
+      const len = Math.hypot(aim.x, aim.y) || 1;
+      const dir = {x: aim.x/len, y: aim.y/len};
+      const duration = CONFIG.brimstone?.beamDuration ?? 2;
+      const tickFrames = Math.max(1, CONFIG.brimstone?.tickFrames ?? 15);
+      if(!Array.isArray(runtime.beams)){ runtime.beams = []; }
+      if(this.brimstoneBeam){
+        endBeam(this.brimstoneBeam);
+      }
+      const beam = {
+        owner: this,
+        dir,
+        timer: duration,
+        tickTimer: 0,
+        tickInterval: tickFrames / 60,
+        damageScale: CONFIG.brimstone?.damageScale ?? 0.7,
+      };
+      runtime.beams.push(beam);
+      this.brimstoneBeam = beam;
+      this.brimstoneFiring = true;
+      this.brimstoneBeamTimer = duration;
+      this.brimstoneCharge = 0;
+      this.brimstoneCharged = false;
+      this.brimstoneCharging = false;
+    }
     applyImpulse(dx,dy,strength){
       const len = Math.hypot(dx,dy) || 1;
       const power = strength || CONFIG.bomb.knock;
@@ -2527,6 +2913,7 @@
         if(typeof snapshot.canPierceObstacles === 'boolean'){ this.canPierceObstacles = snapshot.canPierceObstacles; }
       }
       this.roomBuff = null;
+      this.updateBrimstoneChargeMetrics();
       this.recalculateDamage();
     }
     applyRoomBuff(buff){
@@ -5683,6 +6070,32 @@
     }
   }
 
+  function drawBeams(){
+    if(!runtime.beams || !runtime.beams.length) return;
+    for(const beam of runtime.beams){
+      const geom = computeBeamGeometry(beam);
+      if(!geom || geom.length<=0) continue;
+      const owner = beam.owner;
+      const width = owner?.getBrimstoneWidth?.() ?? beam.width ?? 24;
+      const half = Math.max(4, width * 0.5);
+      ctx.save();
+      ctx.translate(geom.startX, geom.startY);
+      ctx.rotate(Math.atan2(geom.endY - geom.startY, geom.endX - geom.startX));
+      const length = geom.length;
+      const gradient = ctx.createLinearGradient(0, 0, length, 0);
+      gradient.addColorStop(0, colorWithAlpha('#fde68a',0.85));
+      gradient.addColorStop(0.2, colorWithAlpha('#fca5a5',0.82));
+      gradient.addColorStop(0.55, colorWithAlpha('#f97316',0.7));
+      gradient.addColorStop(1, colorWithAlpha('#f97316',0.05));
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, -half, length, half*2);
+      ctx.strokeStyle = colorWithAlpha('#fb7185',0.6);
+      ctx.lineWidth = Math.max(2, half*0.35);
+      ctx.strokeRect(0, -half, length, half*2);
+      ctx.restore();
+    }
+  }
+
   function drawBurstEffect(effect){
     const ttl = effect.ttl || 0.0001;
     const progress = clamp(1 - (effect.life/ttl), 0, 1);
@@ -5793,6 +6206,7 @@
     bullets: [],
     enemyProjectiles: [],
     pendingEnemySpawns: [],
+    beams: [],
     bossIntroTimer: 0,
     bossIntroText: '',
     itemPickupTimer: 0,
@@ -5860,6 +6274,7 @@
     runtime.bullets.length = 0;
     runtime.enemyProjectiles.length = 0;
     runtime.pendingEnemySpawns.length = 0;
+    runtime.beams = [];
     runtime.bossIntroTimer = 0;
     runtime.bossIntroText = '';
     runtime.itemPickupTimer = 0;
@@ -5904,9 +6319,11 @@
     player.lastDisplacement.y = 0;
     if(player.lastVelocity){ player.lastVelocity.x = 0; player.lastVelocity.y = 0; }
     player.ifr = 0;
+    if(typeof player.interruptBrimstoneBeam === 'function'){ player.interruptBrimstoneBeam(); }
     runtime.bullets.length = 0;
     runtime.enemyProjectiles.length = 0;
     runtime.pendingEnemySpawns.length = 0;
+    runtime.beams = [];
     runtime.bossIntroTimer = 0;
     runtime.bossIntroText = '';
     runtime.itemPickupName = `已抵达第 ${currentFloor} 层`;
@@ -6001,6 +6418,20 @@
   function circleRectOverlap(circle, rect){
     return rectCircleOverlap(rect.x, rect.y, rect.w, rect.h, circle.x, circle.y, circle.r);
   }
+  function pointSegmentDistance(px,py, ax,ay, bx,by){
+    const dx = bx - ax;
+    const dy = by - ay;
+    const lenSq = dx*dx + dy*dy;
+    let t = 0;
+    if(lenSq > 1e-6){
+      t = ((px - ax) * dx + (py - ay) * dy) / lenSq;
+    }
+    t = clamp(t, 0, 1);
+    const cx = ax + dx * t;
+    const cy = ay + dy * t;
+    const distSq = (px - cx)*(px - cx) + (py - cy)*(py - cy);
+    return {distance: Math.sqrt(Math.max(0, distSq)), t, cx, cy};
+  }
   function resolveEntityObstacles(entity){
     if(!dungeon?.current) return;
     if(entity===player){
@@ -6082,6 +6513,7 @@
     const enemies = dungeon.current.enemies;
     for(const e of enemies) e.update(dt);
     if(runtime.pendingEnemySpawns.length){ enemies.push(...runtime.pendingEnemySpawns.splice(0)); }
+    updateBeams(dt);
 
     // 敌方弹幕
     for(const eb of runtime.enemyProjectiles){ eb.update(dt); }
@@ -6152,6 +6584,10 @@
             player.recalculateDamage();
           } else {
             pushPickup(p, player, shove);
+          }
+        } else if(p.type==='life-trade'){
+          if(attemptLifeTradePickup(p)){
+            picks.splice(i,1);
           }
         } else if(p.type==='item'){
           pickupItem(p);
@@ -6251,6 +6687,7 @@
     for(const e of dungeon.current.enemies){ e.draw(); }
 
     drawEffects();
+    drawBeams();
 
     for(const eb of runtime.enemyProjectiles){ eb.draw(); }
 
@@ -6382,6 +6819,8 @@
       drawHeartPickup(p);
     } else if((p.type==='bomb' || p.type==='key' || p.type==='coin') && !p.entry){
       drawResourcePickup(p);
+    } else if(p.type==='life-trade' && p.item){
+      drawLifeTradePickup(p);
     } else if(p.type==='item' && p.item){
       drawItemPickup(p);
     } else if(p.type==='card' && p.card){
@@ -6489,6 +6928,46 @@
     ctx.font = '12px "HYWenHei", "PingFang SC", sans-serif';
     ctx.textAlign='center';
     ctx.fillText(p.item.name, p.x, p.y - 32);
+    ctx.restore();
+  }
+
+  function drawLifeTradePickup(p){
+    const bob = Math.sin(performance.now()/520)*4;
+    ctx.save();
+    ctx.translate(p.x, p.y);
+    const base = ctx.createRadialGradient(0, -12, 8, 0, -12, p.r*2.2);
+    base.addColorStop(0, colorWithAlpha('#fca5a5', 0.85));
+    base.addColorStop(0.6, colorWithAlpha('#f87171', 0.35));
+    base.addColorStop(1, colorWithAlpha('#7f1d1d', 0));
+    ctx.fillStyle = base;
+    ctx.beginPath();
+    ctx.arc(0, -12, p.r*2.2, 0, Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = colorWithAlpha('#111827',0.55);
+    ctx.beginPath();
+    ctx.ellipse(0, 20, 20, 6, 0, 0, Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = colorWithAlpha('#1f2937',0.75);
+    ctx.beginPath();
+    ctx.ellipse(0, 18, 28, 9, 0, 0, Math.PI*2);
+    ctx.fill();
+    ctx.save();
+    ctx.translate(0, bob-6);
+    ctx.shadowColor = colorWithAlpha('#f97316',0.65);
+    ctx.shadowBlur = 20;
+    drawItemIcon(p.item.slug, p.r*0.95);
+    ctx.shadowBlur = 0;
+    ctx.restore();
+    ctx.restore();
+    ctx.save();
+    ctx.fillStyle = '#fecaca';
+    ctx.font = '12px "HYWenHei", "PingFang SC", sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(p.item?.name || '生命交易', p.x, p.y - 36);
+    if(p.costLabel){
+      ctx.fillStyle = '#fca5a5';
+      ctx.fillText(p.costLabel, p.x, p.y - 20);
+    }
     ctx.restore();
   }
 
@@ -6744,6 +7223,33 @@
       g.beginPath(); g.arc(0,0,r*0.95,0,Math.PI*2); g.stroke();
       g.fillStyle='#34d399';
       g.beginPath(); g.arc(0,r*0.05,r*0.18,0,Math.PI*2); g.fill();
+    } else if(id==='brimstone'){
+      g.save();
+      const glow = g.createRadialGradient(0,0,r*0.15,0,0,r*0.9);
+      glow.addColorStop(0, '#f97316');
+      glow.addColorStop(0.5, '#ef4444');
+      glow.addColorStop(1, '#7f1d1d');
+      g.fillStyle = glow;
+      g.beginPath();
+      g.arc(0,0,r*0.92,0,Math.PI*2);
+      g.fill();
+      g.strokeStyle = colorWithAlpha('#fee2e2',0.85);
+      g.lineWidth = Math.max(2, r*0.22);
+      g.beginPath();
+      g.moveTo(-r*0.7,0);
+      g.lineTo(r*0.7,0);
+      g.stroke();
+      g.strokeStyle = colorWithAlpha('#fecaca',0.7);
+      g.lineWidth = Math.max(1.5, r*0.16);
+      g.beginPath();
+      g.moveTo(-r*0.58,-r*0.28);
+      g.lineTo(r*0.58,-r*0.28);
+      g.stroke();
+      g.beginPath();
+      g.moveTo(-r*0.58,r*0.28);
+      g.lineTo(r*0.58,r*0.28);
+      g.stroke();
+      g.restore();
     } else if(id==='magic-bullet'){
       g.fillStyle='#a855f7';
       g.beginPath(); g.arc(0,0,r*0.75,0,Math.PI*2); g.fill();
@@ -6922,7 +7428,36 @@
   }
   function drawPlayer(){
     // 身体
-    drawBlob(player.x, player.y, player.r, '#e1e7ff', '#a78bfa');
+    let baseColor = '#e1e7ff';
+    let edgeColor = '#a78bfa';
+    if(player.attackMode === 'brimstone'){
+      const ratio = typeof player.getBrimstoneChargeRatio === 'function' ? player.getBrimstoneChargeRatio() : 0;
+      if(player.brimstoneBeam || player.brimstoneFiring){
+        baseColor = '#f87171';
+        edgeColor = '#b91c1c';
+      } else if(player.brimstoneCharged){
+        baseColor = '#fca5a5';
+        edgeColor = '#dc2626';
+      } else if(ratio>0){
+        baseColor = mixHexColor('#e1e7ff', '#fca5a5', ratio);
+        edgeColor = mixHexColor('#a78bfa', '#ef4444', ratio);
+      }
+    }
+    drawBlob(player.x, player.y, player.r, baseColor, edgeColor);
+    if(player.attackMode === 'brimstone' && (player.brimstoneBeam || player.brimstoneCharged)){
+      const pulse = player.brimstoneBeam ? 1 : clamp(player.getBrimstoneChargeRatio?.() ?? 0, 0, 1);
+      const radius = player.r * (1.25 + pulse * 0.35);
+      ctx.save();
+      ctx.globalAlpha = 0.35 + pulse * 0.25;
+      const halo = ctx.createRadialGradient(player.x, player.y, radius*0.35, player.x, player.y, radius);
+      halo.addColorStop(0, colorWithAlpha('#fca5a5', 0.9));
+      halo.addColorStop(1, colorWithAlpha('#b91c1c', 0));
+      ctx.fillStyle = halo;
+      ctx.beginPath();
+      ctx.arc(player.x, player.y, radius, 0, Math.PI*2);
+      ctx.fill();
+      ctx.restore();
+    }
     // 眼泪闪烁（无敌帧提示）
     if(player.ifr>0){ ctx.save(); ctx.globalAlpha = 0.5 + 0.5*Math.sin(performance.now()/60); ctx.strokeStyle='#fff'; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(player.x,player.y,player.r+3,0,Math.PI*2); ctx.stroke(); ctx.restore(); }
   }


### PR DESCRIPTION
## Summary
- introduce the life-trade configuration, pool combination, pickup creation/cost handling, and starting-room spawn with dedicated visuals
- integrate the Brimstone passive into the life-trade pool and extend the player with charge-based beam firing, beam runtime management, and rendering support
- add supporting helpers for color blending, Brimstone charge feedback, and icon art for the new item

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d25a11a384832cb840c26df76dc143