### PR TITLE
Adjust brimstone charge time

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,7 @@
       beamDuration: 2,
       damageScale: 0.7,
       widthGrowth: 1.5,
+      chargeScale: 2.25,
     },
     progression: {
       enemyHp: 1.2,
@@ -2583,7 +2584,8 @@
       this.brimstoneCharging = false;
       this.brimstoneCharged = false;
       this.brimstoneCharge = 0;
-      this.brimstoneChargeTime = Math.max(0.2, (this.fireInterval || CONFIG.player.fireCd)/1000);
+      const brimstoneChargeScale = CONFIG?.brimstone?.chargeScale ?? 2.25;
+      this.brimstoneChargeTime = Math.max(0.2, ((this.fireInterval || CONFIG.player.fireCd)/1000) * brimstoneChargeScale);
       this.brimstoneAim = {x:0, y:-1};
       this.brimstoneBeam = null;
       this.brimstoneFiring = false;
@@ -2814,7 +2816,8 @@
     }
     updateBrimstoneChargeMetrics(){
       const interval = Number.isFinite(this.fireInterval) ? this.fireInterval : (CONFIG.player.fireCd || 360);
-      this.brimstoneChargeTime = Math.max(0.15, interval / 1000);
+      const brimstoneChargeScale = CONFIG?.brimstone?.chargeScale ?? 2.25;
+      this.brimstoneChargeTime = Math.max(0.15, (interval / 1000) * brimstoneChargeScale);
     }
     ensureBrimstoneMode(){
       if(this.attackMode !== 'brimstone'){


### PR DESCRIPTION
## Summary
- add a configurable chargeScale for the brimstone configuration and set it to 2.25
- scale brimstone's initial and recalculated charge times by the configured multiplier so the beam takes longer to charge

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d265ddd65c832cbe3d7f13cc3c15c9