### PR TITLE
Adjust brimstone charge time

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
       beamDuration: 2,
       damageScale: 0.7,
       widthGrowth: 1.5,
-      chargeScale: 11.25,
+      chargeScale: 4.5,
     },
     progression: {
       enemyHp: 1.2,


### PR DESCRIPTION
## Summary
- reduce the brimstone item's charge time multiplier so the beam charges 2.5x faster

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d269245568832c9b582dc5990ad089