### PR TITLE
Add dynamic shadows and document enemy types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Contextual overlays at start, pause, and game over; hit **“我要出发！”*
 
   *Boss telegraphs now glow per action and the HUD item list tallies every stack.*
 
+- **动态阴影 · Dynamic Shadows**
+  玩家与怪物依据飞行 / 贴地状态渲染不同阴影轮廓，悬浮高度与压迫感一眼可辨。
+
+  *Dynamic contact shadows differentiate grounded vs. flying units at a glance.*
+
 - **小地图与事件可视化 · Readable Flow**
   小地图颜色区分：当前房间 / Boss / 道具房 / 商店；另有 **Boss 血条、开场介绍与拾取横幅**。  
   *Minimap color-codes key rooms; boss bars and pickup banners spotlight beats.*
@@ -77,10 +82,11 @@ Contextual overlays at start, pause, and game over; hit **“我要出发！”*
 
 ## 战斗循环 · Combat Loop
 
-- **移动**：带加速/减速惯性，上限速度可被道具突破。  
-- **射击**：独立冷却；实时重算伤害、半径、穿透、追踪。  
-- **炸弹**：击退、连锁与震屏；可摧毁障碍或引出隐藏掉落。  
-*Movement uses acceleration/drift; tears recalc stats; bombs shove/chain/shake and reveal secrets.*
+- **移动**：带加速/减速惯性，上限速度可被道具突破。
+- **射击**：独立冷却；实时重算伤害、半径、穿透、追踪。
+- **炸弹**：击退、连锁与震屏；可摧毁障碍或引出隐藏掉落。
+- **阴影反馈**：飞行单位的阴影更小更淡，跃起 Boss 的阴影会随高度收缩。
+*Movement uses acceleration/drift; tears recalc stats; bombs shove/chain/shake and reveal secrets. Shadow feedback shrinks airborne foes and scales boss leaps.*
 
 ---
 
@@ -181,21 +187,21 @@ Contextual overlays at start, pause, and game over; hit **“我要出发！”*
 
 ## 怪物图鉴 · Monster Bestiary
 
-| 敌人 · Enemy | 行为 · Behavior（简述） |
-|:--|:--|
-| 追击者 · *Chaser* | 直线猛冲；受击短暂后退。*Charges straight; recoils on hit.* |
-| 轨道蛆 · *Orbiter* | 绕行锚点缓慢逼近。*Orbits a drifting anchor.* |
-| 气囊怪 · *Gasbag* | 近身点燃自爆，弹出小飞虫。*Explodes into Tiny Flies.* |
-| 分裂体 · *Splitter* | 死亡分裂再集结。*Splits into smaller clones.* |
-| 易爆蛞蝓 · *Volatile* | 触发引线，蓄满即爆。*Fuse → wide blast.* |
-| 小飞虫 · *Tiny Fly* | 贴脸骚扰，弹飞再冲刺。*Buzz, bounce, re-engage.* |
-| 老飞虫 · *Elder Fly* | 保持距离绕行并读条射击。*Circles, telegraphed volleys.* |
-| 哨卫 · *Sentry* | 原地锁定，三向弹幕。*Locks on, triple burst.* |
-| 冲刺鬼 · *Dashling* | 预兆→高速冲刺→疲劳循环。*Telegraph → lunge → recover.* |
-| 潜伏者 · *Burrower* | 潜地追踪，出土直刺。*Burrow and erupt lunge.* |
-| 火花灵 · *Spark* | 小半径轨道，环形电弧弹。*Radial spark bursts.* |
-| 育母虫 · *Brood* | 中距离孵化小飞虫。*Spawns minions in radius.* |
-| 蜘蛛跃者 · *Spider Leaper* | 读条弹跳落地冲击，狂暴加速。*Telegraphed acrobatics.* |
+| 敌人 · Enemy | 类型 · Type | 行为 · Behavior（简述） |
+|:--|:--:|:--|
+| 追击者 · *Chaser* | 地面 · Ground | 直线猛冲；受击短暂后退。*Charges straight; recoils on hit.* |
+| 轨道蛆 · *Orbiter* | 飞行 · Flying | 绕行锚点缓慢逼近。*Orbits a drifting anchor.* |
+| 气囊怪 · *Gasbag* | 地面 · Ground | 近身点燃自爆，弹出小飞虫。*Explodes into Tiny Flies.* |
+| 分裂体 · *Splitter* | 地面 · Ground | 死亡分裂再集结。*Splits into smaller clones.* |
+| 易爆蛞蝓 · *Volatile* | 地面 · Ground | 触发引线，蓄满即爆。*Fuse → wide blast.* |
+| 小飞虫 · *Tiny Fly* | 飞行 · Flying | 贴脸骚扰，弹飞再冲刺。*Buzz, bounce, re-engage.* |
+| 老飞虫 · *Elder Fly* | 飞行 · Flying | 保持距离绕行并读条射击。*Circles, telegraphed volleys.* |
+| 哨卫 · *Sentry* | 地面 · Ground | 原地锁定，三向弹幕。*Locks on, triple burst.* |
+| 冲刺鬼 · *Dashling* | 地面 · Ground | 预兆→高速冲刺→疲劳循环。*Telegraph → lunge → recover.* |
+| 潜伏者 · *Burrower* | 地面 · Ground | 潜地追踪，出土直刺。*Burrow and erupt lunge.* |
+| 火花灵 · *Spark* | 飞行 · Flying | 小半径轨道，环形电弧弹。*Radial spark bursts.* |
+| 育母虫 · *Brood* | 地面 · Ground | 中距离孵化小飞虫。*Spawns minions in radius.* |
+| 蜘蛛跃者 · *Spider Leaper* | 地面 · Ground | 读条弹跳落地冲击，狂暴加速。*Telegraphed acrobatics.* |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -8915,6 +8915,12 @@
         ctx.restore();
       }
     }
+    getShadowConfig(){
+      if(this.state==='burrow'){
+        return {visible:false};
+      }
+      return null;
+    }
     damage(d){
       if(this.state==='burrow') return false;
       this.hp -= d;
@@ -9249,13 +9255,6 @@
     }
     draw(){
       const altitude = this.getAltitude();
-      ctx.save();
-      ctx.globalAlpha = 0.35 + 0.25*altitude;
-      ctx.fillStyle = '#0006';
-      ctx.beginPath();
-      ctx.ellipse(this.x, this.y + this.r*0.9, this.r*(1-altitude*0.35), this.r*0.6*(1-altitude*0.45), 0, 0, Math.PI*2);
-      ctx.fill();
-      ctx.restore();
       const telegraphing = this.state==='telegraph';
       const base = telegraphing ? '#fed7aa' : '#cbd5f5';
       const edge = telegraphing ? '#f97316' : '#8b5cf6';
@@ -9268,6 +9267,19 @@
       ctx.arc(this.r*0.35, -this.r*0.1, this.r*0.18, 0, Math.PI*2);
       ctx.fill();
       ctx.restore();
+    }
+    getShadowConfig(){
+      const altitude = clamp(this.getAltitude?.() ?? 0, 0, 1.2);
+      return {
+        x: this.x,
+        y: this.y,
+        radius: this.r,
+        altitude,
+        flying: altitude>0.05,
+        alpha: 0.35 + 0.25*altitude,
+        stretch: 0.6,
+        scale: 1 - altitude*0.35,
+      };
     }
   }
 
@@ -9666,13 +9678,6 @@
     draw(){
       const telegraph = this.state==='telegraph-jump' || this.state==='telegraph-wave';
       const enraged = this.enraged;
-      ctx.save();
-      ctx.globalAlpha = 0.4 + 0.3*this.altitude;
-      ctx.fillStyle = '#0007';
-      ctx.beginPath();
-      ctx.ellipse(this.x, this.y + this.r*0.9, this.r*(1 - this.altitude*0.4), this.r*0.6*(1 - this.altitude*0.45), 0, 0, Math.PI*2);
-      ctx.fill();
-      ctx.restore();
       let base = this.hitFlash>0 ? '#ffe6ef' : (enraged ? '#f87171' : '#ffcad6');
       let edge = enraged ? '#ef4444' : '#f472b6';
       if(telegraph){
@@ -10000,6 +10005,19 @@
         ctx.stroke();
         ctx.restore();
       }
+    }
+    getShadowConfig(){
+      const altitude = clamp(Number(this.altitude) || 0, 0, 1.2);
+      return {
+        x: this.x,
+        y: this.y,
+        radius: this.r,
+        altitude,
+        flying: altitude>0.05,
+        alpha: 0.4 + 0.3*altitude,
+        stretch: 0.6,
+        scale: 1 - altitude*0.4,
+      };
     }
   }
 
@@ -10590,15 +10608,6 @@
       return false;
     }
     draw(){
-      ctx.save();
-      const shadowAlpha = 0.35 + 0.3*this.altitude;
-      ctx.globalAlpha = shadowAlpha;
-      ctx.fillStyle = '#0008';
-      ctx.beginPath();
-      ctx.ellipse(this.x, this.y + this.r*0.9, this.r*(1 - this.altitude*0.3), this.r*0.55*(1 - this.altitude*0.35), 0, 0, Math.PI*2);
-      ctx.fill();
-      ctx.restore();
-
       let baseColor = this.hitFlash>0 ? '#fee2e2' : (this.enraged ? '#fed7aa' : '#fecaca');
       let edgeColor = this.enraged ? '#f97316' : '#fb7185';
       if(this.state==='windup' && this.telegraphType){
@@ -10651,6 +10660,19 @@
         ctx.stroke();
         ctx.restore();
       }
+    }
+    getShadowConfig(){
+      const altitude = clamp(Number(this.altitude) || 0, 0, 1.2);
+      return {
+        x: this.x,
+        y: this.y,
+        radius: this.r,
+        altitude,
+        flying: altitude>0.05,
+        alpha: 0.35 + 0.3*altitude,
+        stretch: 0.55,
+        scale: 1 - altitude*0.3,
+      };
     }
   }
 
@@ -10885,6 +10907,108 @@
       ctx.fill();
       ctx.restore();
     }
+  }
+
+  function getShadowConfigForEntity(entity){
+    if(!entity || entity.shadow === false || entity.noShadow === true) return null;
+    let cfg = undefined;
+    if(typeof entity.getShadowConfig === 'function'){
+      cfg = entity.getShadowConfig();
+      if(cfg === false || (cfg && cfg.visible === false)){
+        return null;
+      }
+    }
+    cfg = cfg ? {...cfg} : {};
+    const x = Number.isFinite(cfg.x) ? cfg.x : Number(entity.shadowX ?? entity.x);
+    const y = Number.isFinite(cfg.y) ? cfg.y : Number(entity.shadowY ?? entity.y);
+    const radius = Number.isFinite(cfg.radius) ? cfg.radius : Number(entity.shadowRadius ?? entity.r ?? 12);
+    if(!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(radius) || radius<=0){
+      return null;
+    }
+    const flying = cfg.flying ?? !!entity.flying;
+    let altitude = cfg.altitude;
+    if(!Number.isFinite(altitude)){
+      if(typeof entity.getShadowAltitude === 'function'){
+        altitude = Number(entity.getShadowAltitude());
+      }
+      if(!Number.isFinite(altitude) && typeof entity.getAltitude === 'function'){
+        altitude = Number(entity.getAltitude());
+      }
+      if(!Number.isFinite(altitude) && Number.isFinite(entity.altitude)){
+        altitude = Number(entity.altitude);
+      }
+      if(!Number.isFinite(altitude) && Number.isFinite(entity.shadowAltitude)){
+        altitude = Number(entity.shadowAltitude);
+      }
+    }
+    if(!Number.isFinite(altitude)){ altitude = 0; }
+    altitude = clamp(altitude, 0, 1.6);
+    if(flying && altitude<=0){
+      const hover = Number.isFinite(cfg.hover) ? cfg.hover : Number(entity.shadowHover ?? 0.32);
+      if(Number.isFinite(hover) && hover>0){
+        altitude = clamp(hover, 0, 1.2);
+      }
+    }
+    const hasCustomAlpha = Number.isFinite(cfg.alpha) || Number.isFinite(entity.shadowAlpha);
+    const baseAlpha = Number.isFinite(cfg.alpha) ? cfg.alpha
+      : Number.isFinite(entity.shadowAlpha) ? entity.shadowAlpha
+      : (flying ? 0.3 : 0.45);
+    const stretch = Number.isFinite(cfg.stretch) ? cfg.stretch
+      : Number.isFinite(entity.shadowStretch) ? entity.shadowStretch
+      : (flying ? 0.55 : 0.48);
+    const scaleBase = Number.isFinite(cfg.scale) ? cfg.scale
+      : Number.isFinite(entity.shadowScale) ? entity.shadowScale
+      : (1 - altitude * (flying ? 0.55 : 0.38));
+    const scale = clamp(scaleBase, flying ? 0.45 : 0.6, flying ? 1.05 : 1.15);
+    let offsetY;
+    if(Number.isFinite(cfg.offsetY)){
+      offsetY = cfg.offsetY;
+    } else if(Number.isFinite(entity.shadowOffsetY)){
+      offsetY = entity.shadowOffsetY;
+    } else {
+      const factor = Number.isFinite(cfg.offsetFactor) ? cfg.offsetFactor
+        : Number.isFinite(entity.shadowOffsetFactor) ? entity.shadowOffsetFactor
+        : (flying ? 0.75 : 0.9);
+      offsetY = radius * clamp(factor, 0.2, 1.4);
+    }
+    const color = cfg.color || entity.shadowColor || '#000000';
+    const alpha = hasCustomAlpha
+      ? clamp(baseAlpha, 0.05, 0.8)
+      : clamp(baseAlpha - altitude * (flying ? 0.08 : 0.22), 0.05, 0.7);
+    return {
+      x,
+      y,
+      radius,
+      altitude,
+      flying,
+      alpha,
+      stretch: clamp(stretch, 0.15, 1.4),
+      scale,
+      offsetY,
+      color,
+    };
+  }
+
+  function drawShadowFromConfig(cfg){
+    if(!cfg) return;
+    const x = cfg.x;
+    const y = cfg.y;
+    const radius = cfg.radius;
+    if(!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(radius) || radius<=0) return;
+    ctx.save();
+    ctx.globalAlpha = clamp(cfg.alpha ?? 0.4, 0.01, 0.8);
+    ctx.fillStyle = cfg.color || '#000000';
+    ctx.beginPath();
+    ctx.ellipse(x, y + (cfg.offsetY ?? radius*0.85), radius * (cfg.scale ?? 1), radius * (cfg.stretch ?? 0.5) * (cfg.scale ?? 1), 0, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+  }
+
+  function drawEntityShadow(entity){
+    if(!entity) return;
+    const cfg = getShadowConfigForEntity(entity);
+    if(!cfg) return;
+    drawShadowFromConfig(cfg);
   }
 
   function drawBlob(x,y,r,base,edge){
@@ -13314,6 +13438,7 @@
     for(const bomb of dungeon.current.bombs){ bomb.draw(); }
 
     for(const e of dungeon.current.enemies){
+      drawEntityShadow(e);
       e.draw();
       if(e.damageFlashTimer>0){
         const ratio = clamp(e.damageFlashTimer / ENEMY_DAMAGE_FLASH_DURATION, 0, 1);
@@ -14445,6 +14570,7 @@
         edgeColor = mixHexColor(edgeColor, '#38bdf8', strength);
       }
     }
+    drawEntityShadow(player);
     ctx.save();
     if(player.ifr>0){
       const phase = Math.floor((performance.now()/70)) % 2;


### PR DESCRIPTION
## Summary
- add a shared shadow renderer that scales alpha/shape based on flying or grounded state and use it in the main draw loop and player rendering
- expose per-enemy shadow configs so burrowers hide underground halos while bosses keep altitude-aware scaling
- document the new shadow system and mark each monster as ground or flying in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4ace73a34832cb606b44059af37cf