### PR TITLE
Add chest drops and update coin visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,9 @@
     },
     loot: {
       bossRareChance: 0.06,
+      silverChestChance: 0.1,
+      goldChestChance: 0.05,
+      goldChestItemChance: 0.05,
     },
     cards: {
       price: 5,
@@ -306,11 +309,63 @@
     rngSeed: Date.now() % 1000000,
   };
 
+  const CHEST_VARIANTS = {
+    silver: {
+      keyCost: 0,
+      mass: 2.1,
+      openDuration: 0.45,
+      minDrops: 1,
+      maxDrops: 3,
+      scatter: 30,
+      dropOptions: [
+        {type: 'key', min: 1, max: 2},
+        {type: 'bomb', min: 1, max: 2},
+        {type: 'coin', min: 3, max: 6},
+      ],
+      palette: {
+        base: '#9ca3af',
+        shadow: '#4b5563',
+        trim: '#e2e8f0',
+        accent: '#60a5fa',
+        hinge: '#94a3b8',
+        glow: '#cbd5f5',
+      },
+    },
+    gold: {
+      keyCost: 1,
+      mass: 2.6,
+      openDuration: 0.48,
+      minDrops: 3,
+      maxDrops: 4,
+      scatter: 34,
+      dropOptions: [
+        {type: 'key', min: 3, max: 5},
+        {type: 'bomb', min: 3, max: 5},
+        {type: 'coin', min: 6, max: 10},
+      ],
+      palette: {
+        base: '#f59e0b',
+        shadow: '#b45309',
+        trim: '#fde68a',
+        accent: '#fef3c7',
+        hinge: '#78350f',
+        glow: '#fcd34d',
+      },
+    },
+  };
+
   // ======= 基础工具 =======
   const rand = mulberry32(CONFIG.rngSeed);
   function mulberry32(a){return function(){let t=a+=0x6D2B79F5;t=Math.imul(t^t>>>15,t|1);t^=t+Math.imul(t^t>>>7,t|61);return((t^t>>>14)>>>0)/4294967296}};
   function randRange(min,max){return min + (max-min)*rand()}
+  function randInt(min,max){
+    const a = Math.ceil(min);
+    const b = Math.floor(max);
+    if(b<a) return a;
+    return Math.floor(randRange(a, b+1));
+  }
   function clamp(v,a,b){return Math.max(a,Math.min(b,v))}
+  function clamp01(v){ return clamp(v,0,1); }
   function dist(a,b){const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy)}
   const PICKUP_BANNER_TIME_SCALE = 1.6;
   function isTimeStopActive(){
@@ -3404,6 +3459,192 @@
     const amount = Math.max(1, cost.amount ?? Math.floor(CONFIG.lifeTrade?.defaultCost ?? 2));
     return `需要至少 ${amount + 1} 点生命上限。`;
   }
+  function getChestConfig(variant){
+    return CHEST_VARIANTS[variant] || CHEST_VARIANTS.silver;
+  }
+  function makeLooseItemPickup(x,y,item){
+    if(!item) return null;
+    return {
+      type:'item',
+      x:clamp(x,80,CONFIG.roomW-80),
+      y:clamp(y,90,CONFIG.roomH-90),
+      r:18,
+      item:{...item},
+      room:null,
+      vx:0,
+      vy:0,
+      solid:false,
+    };
+  }
+  function makeChest(variant,x,y,options={}){
+    const config = getChestConfig(variant);
+    const radius = Math.max(16, Number(options.radius) || 18);
+    const px = clamp(options.x ?? x, 80, CONFIG.roomW-80);
+    const py = clamp(options.y ?? y, 90, CONFIG.roomH-90);
+    const chest = {
+      type:'chest',
+      variant: variant || 'silver',
+      x:px,
+      y:py,
+      r:radius,
+      vx:0,
+      vy:0,
+      solid:true,
+      spawnGrace: Math.min(CONFIG.pickupSpawnGrace, 0.35),
+      opening:false,
+      openTimer:0,
+      openProgress:0,
+      openDuration: Number.isFinite(options.openDuration) ? Math.max(0.12, options.openDuration) : (config.openDuration || 0.45),
+      opened:false,
+      lootSpawned:false,
+      removeOnExit:false,
+      keyCost: Number.isFinite(options.keyCost) ? Math.max(0, options.keyCost) : Math.max(0, config.keyCost || 0),
+      mass: Number.isFinite(options.mass) ? Math.max(0.5, options.mass) : Math.max(1, config.mass || 2),
+      palette: options.palette || config.palette,
+      scatter: Number.isFinite(options.scatter) ? Math.max(12, options.scatter) : Math.max(16, config.scatter || 30),
+      dropOptions: Array.isArray(options.dropOptions) && options.dropOptions.length ? options.dropOptions.slice() : (config.dropOptions || []),
+      itemChance: Number.isFinite(options.itemChance) ? clamp(options.itemChance, 0, 1) : undefined,
+      glowPhase: rand()*Math.PI*2,
+    };
+    chest.locked = chest.keyCost>0;
+    return chest;
+  }
+  function findChestSpawnPosition(room, radius){
+    if(!room){
+      return {x:clamp(CONFIG.roomW/2, 80, CONFIG.roomW-80), y:clamp(CONFIG.roomH/2, 90, CONFIG.roomH-90)};
+    }
+    const marginX = Math.max(80, radius + 48);
+    const marginY = Math.max(90, radius + 52);
+    for(let attempt=0; attempt<64; attempt++){
+      const x = randRange(marginX, CONFIG.roomW - marginX);
+      const y = randRange(marginY, CONFIG.roomH - marginY);
+      const circle = {x, y, r: radius};
+      let blocked = false;
+      if(Array.isArray(room.obstacles)){
+        for(const obs of room.obstacles){
+          if(obs?.destroyed) continue;
+          if(circleRectOverlap(circle, obs)){ blocked = true; break; }
+        }
+      }
+      if(blocked) continue;
+      if(Array.isArray(room.pickups)){
+        for(const other of room.pickups){
+          if(!other || !other.solid) continue;
+          if(dist(other, circle) < (other.r || radius) + radius + 8){ blocked = true; break; }
+        }
+      }
+      if(Array.isArray(room.bombs)){
+        for(const bomb of room.bombs){
+          if(!bomb || bomb.done) continue;
+          if(dist(bomb, circle) < (bomb.r || 18) + radius + 6){ blocked = true; break; }
+        }
+      }
+      if(blocked) continue;
+      return {x, y};
+    }
+    const fallbackX = clamp(room.center?.().x ?? CONFIG.roomW/2, marginX, CONFIG.roomW - marginX);
+    const fallbackY = clamp(room.center?.().y ?? CONFIG.roomH/2, marginY, CONFIG.roomH - marginY);
+    return {x: fallbackX, y: fallbackY};
+  }
+  function spawnChestInRoom(room, variant, options={}){
+    if(!room) return null;
+    if(!Array.isArray(room.pickups)) room.pickups = [];
+    const radius = Math.max(16, Number(options.radius) || 18);
+    const pos = options.position || findChestSpawnPosition(room, radius);
+    const chest = makeChest(variant, pos.x, pos.y, Object.assign({}, options, {radius}));
+    room.pickups.push(chest);
+    return chest;
+  }
+  function chestRequiresKey(chest){
+    return !!(chest && (chest.keyCost || 0) > 0);
+  }
+  function openChest(chest, room){
+    if(!chest || chest.type!=='chest') return false;
+    if(chest.opened || chest.opening) return false;
+    chest.opening = true;
+    chest.openTimer = 0;
+    chest.openProgress = 0;
+    chest.spawnGrace = 0;
+    chest.removeOnExit = true;
+    chest.locked = false;
+    if(typeof chest.onOpen === 'function'){
+      try{ chest.onOpen(chest, room); }catch(err){ console.error(err); }
+    }
+    return true;
+  }
+  function spawnChestLoot(chest, room){
+    if(!room || !chest || chest.lootSpawned) return;
+    const config = getChestConfig(chest.variant);
+    const dropOptions = chest.dropOptions && chest.dropOptions.length ? chest.dropOptions : (config.dropOptions || []);
+    const minDrops = Math.max(1, Math.floor(Number.isFinite(chest.minDrops) ? chest.minDrops : (config.minDrops || 1)));
+    const maxDrops = Math.max(minDrops, Math.floor(Number.isFinite(chest.maxDrops) ? chest.maxDrops : (config.maxDrops || minDrops)));
+    const dropCount = randInt(minDrops, maxDrops);
+    const chosen = [];
+    for(let i=0;i<dropCount;i++){
+      if(!dropOptions.length) break;
+      const option = dropOptions[Math.floor(rand()*dropOptions.length)];
+      if(!option) continue;
+      const amount = randInt(option.min ?? 1, option.max ?? option.min ?? 1);
+      if(amount<=0) continue;
+      chosen.push({type: option.type || 'coin', amount});
+    }
+    if(!chosen.length && dropOptions.length){
+      const option = dropOptions[Math.floor(rand()*dropOptions.length)];
+      if(option){
+        const amount = randInt(option.min ?? 1, option.max ?? option.min ?? 1);
+        chosen.push({type: option.type || 'coin', amount: Math.max(1, amount)});
+      }
+    }
+    if(!chosen.length){
+      chosen.push({type:'coin', amount: randInt(3,6)});
+    }
+    const scatter = Math.max(18, Number.isFinite(chest.scatter) ? chest.scatter : (config.scatter || 28));
+    const baseAngle = rand()*Math.PI*2;
+    const total = chosen.length;
+    for(let i=0;i<total;i++){
+      const drop = chosen[i];
+      const angle = baseAngle + (Math.PI*2) * (i/Math.max(1,total));
+      const distScale = randRange(scatter*0.4, scatter);
+      const px = clamp(chest.x + Math.cos(angle)*distScale, 70, CONFIG.roomW-70);
+      const py = clamp(chest.y + Math.sin(angle)*distScale, 80, CONFIG.roomH-80);
+      const pickup = makeResourcePickup(drop.type, px, py, drop.amount);
+      pickup.spawnGrace = 0.2;
+      room.pickups.push(pickup);
+    }
+    const defaultItemChance = chest.variant==='gold' ? (CONFIG.loot?.goldChestItemChance ?? 0) : 0;
+    const itemChance = clamp(Number.isFinite(chest.itemChance) ? chest.itemChance : (Number.isFinite(config.itemChance) ? config.itemChance : defaultItemChance), 0, 1);
+    if(itemChance>0 && rand()<itemChance){
+      const item = rollItem();
+      if(item){
+        const itemPickup = makeLooseItemPickup(chest.x, chest.y - 8, item);
+        if(itemPickup){
+          itemPickup.spawnGrace = 0.25;
+          room.pickups.push(itemPickup);
+        }
+        if(runtime && runtime.itemPickupTimer<=0){
+          runtime.itemPickupName = '金箱子惊喜';
+          runtime.itemPickupDesc = `${item.name}：${item.description || '来自道具房的馈赠。'}`;
+          runtime.itemPickupTimer = 2.8;
+        }
+      }
+    }
+    chest.lootSpawned = true;
+  }
+  function maybeSpawnChest(room){
+    if(!room) return null;
+    if(room.isBoss || room.isItemRoom || room.isShop) return null;
+    if(!room.combatRoom) return null;
+    const lootCfg = CONFIG.loot || {};
+    const goldChance = clamp(Number(lootCfg.goldChestChance) || 0, 0, 1);
+    const silverChance = clamp(Number(lootCfg.silverChestChance) || 0, 0, 1);
+    if(rand() < goldChance){
+      return spawnChestInRoom(room, 'gold');
+    }
+    if(rand() < silverChance){
+      return spawnChestInRoom(room, 'silver');
+    }
+    return null;
+  }
   function makeResourcePickup(type,x,y,amount){
     return {
       type,
@@ -3416,6 +3657,7 @@
       vy:0,
       solid:true,
       spawnGrace:CONFIG.pickupSpawnGrace,
+      mass: type==='coin' ? 1.15 : (type==='bomb' ? 1.35 : (type==='key' ? 1.1 : 1)),
     };
   }
   function makeCardPickup(x,y,card){
@@ -3612,13 +3854,14 @@
     const dx = p.x - origin.x;
     const dy = p.y - origin.y;
     const d = Math.hypot(dx,dy) || 0.0001;
-    const impulse = strength ?? 180;
+    const mass = Math.max(0.35, Number(p.mass) || 1);
+    const impulse = (strength ?? 180) / mass;
     const nx = dx / d;
     const ny = dy / d;
     p.vx += nx * impulse;
     p.vy += ny * impulse;
     const speed = Math.hypot(p.vx, p.vy);
-    const maxSpeed = 360;
+    const maxSpeed = 360 / Math.max(1, Math.sqrt(mass));
     if(speed > maxSpeed){
       const scale = maxSpeed / speed;
       p.vx *= scale;
@@ -3716,6 +3959,31 @@
     for(const p of picks){
       if(typeof p.spawnGrace === 'number' && p.spawnGrace>0){
         p.spawnGrace = Math.max(0, p.spawnGrace - dt);
+      }
+      if(p.type==='chest'){
+        const config = getChestConfig(p.variant || 'silver');
+        const duration = Math.max(0.1, Number.isFinite(p.openDuration) ? p.openDuration : (config.openDuration || 0.42));
+        if(p.opening){
+          p.openTimer = Math.min(duration, (p.openTimer || 0) + dt);
+          p.openProgress = clamp01(p.openTimer / duration);
+          if(p.openTimer >= duration - 1e-4){
+            p.opening = false;
+            p.opened = true;
+            p.openProgress = 1;
+            if(!p.lootSpawned){
+              spawnChestLoot(p, dungeon.current);
+            }
+          }
+        } else if(p.opened){
+          p.openProgress = clamp01(typeof p.openProgress === 'number' ? p.openProgress : 1);
+          if(!p.lootSpawned){
+            spawnChestLoot(p, dungeon.current);
+          }
+        } else {
+          if(typeof p.openProgress !== 'number' || p.openProgress<0){
+            p.openProgress = 0;
+          }
+        }
       }
       const physical = isPhysicalPickup(p);
       ensurePickupMotion(p);
@@ -16547,6 +16815,9 @@
   function enterRoom(nextRoom, direction, options={}){
     if(!nextRoom) return;
     dungeon.current = nextRoom;
+    if(Array.isArray(nextRoom.pickups)){
+      nextRoom.pickups = nextRoom.pickups.filter(p => !(p && p.type==='chest' && p.opened && p.removeOnExit));
+    }
     if(!nextRoom.visited){ dungeon.depth++; }
     nextRoom.visited = true;
     dungeon.revealRoom(nextRoom);
@@ -16942,6 +17213,7 @@
         const amount = resType==='coin'?4:1;
         dungeon.current.pickups.push(makeResourcePickup(resType, randRange(120,CONFIG.roomW-120), randRange(120,CONFIG.roomH-120), amount));
       }
+      maybeSpawnChest(room);
     }
 
     // 拾取
@@ -16980,10 +17252,41 @@
           } else {
             pushPickup(p, player, shove);
           }
+        } else if(p.type==='chest'){
+          const requiresKey = chestRequiresKey(p);
+          if(p.opened){
+            pushPickup(p, player, shove*0.35);
+            continue;
+          }
+          if(p.opening){
+            pushPickup(p, player, shove*0.25);
+            continue;
+          }
+          if(requiresKey && player.keys<=0){
+            if(runtime.itemPickupTimer<=0){
+              runtime.itemPickupName = '金箱子上锁';
+              runtime.itemPickupDesc = '需要 1 把钥匙才能开启。';
+              runtime.itemPickupTimer = 1.2;
+            }
+            pushPickup(p, player, shove*0.25);
+            continue;
+          }
+          const opened = openChest(p, dungeon.current);
+          if(opened){
+            if(requiresKey){
+              player.keys = Math.max(0, player.keys - 1);
+              player.recalculateDamage?.();
+            }
+            if(runtime.itemPickupTimer<=0){
+              runtime.itemPickupName = p.variant==='gold' ? '金箱子开启' : '银箱子开启';
+              runtime.itemPickupDesc = '宝物洒落在地面。';
+              runtime.itemPickupTimer = 1.3;
+            }
+          }
         } else if(p.type==='card'){
           if(!p.card){
             picks.splice(i,1);
-          } else if(givePlayerCard(p.card, {room: dungeon.current, x: p.x, y: p.y})){ 
+          } else if(givePlayerCard(p.card, {room: dungeon.current, x: p.x, y: p.y})){
             picks.splice(i,1);
           } else {
             pushPickup(p, player, shove);
@@ -17302,7 +17605,9 @@
     ctx.restore();
   }
   function drawPickup(p){
-    if(p.type==='heart'){
+    if(p.type==='chest'){
+      drawChestPickup(p);
+    } else if(p.type==='heart'){
       drawHeartPickup(p);
     } else if((p.type==='bomb' || p.type==='key' || p.type==='coin') && !p.entry){
       drawResourcePickup(p);
@@ -17317,6 +17622,125 @@
     }
   }
 
+  function drawChestPickup(p){
+    const config = getChestConfig(p.variant || 'silver');
+    const palette = p.palette || config.palette || {};
+    const baseColor = palette.base || '#9ca3af';
+    const shadowColor = palette.shadow || '#4b5563';
+    const trimColor = palette.trim || '#e2e8f0';
+    const accentColor = palette.accent || '#60a5fa';
+    const hingeColor = palette.hinge || shadeColor(baseColor, -0.3);
+    const glowColor = palette.glow || colorWithAlpha('#fef3c7',0.8);
+    const progress = clamp01(p.openProgress || 0);
+    const wobble = Math.sin(performance.now()/780 + (p.glowPhase || 0))*1.4;
+    const w = p.r * 2.4;
+    const h = p.r * 1.55;
+    const bodyTop = -h*0.18;
+    const bodyBottom = h*0.62;
+    const lidHeight = h*0.55;
+    ctx.save();
+    ctx.translate(p.x, p.y + wobble);
+    const shadow = ctx.createRadialGradient(0, bodyBottom, p.r*0.2, 0, bodyBottom, p.r*1.6);
+    shadow.addColorStop(0, colorWithAlpha('#0f172a',0.55));
+    shadow.addColorStop(1, colorWithAlpha('#0f172a',0));
+    ctx.fillStyle = shadow;
+    ctx.beginPath();
+    ctx.ellipse(0, bodyBottom+4, p.r*1.55, p.r*0.55, 0, 0, Math.PI*2);
+    ctx.fill();
+    if(p.variant==='gold' && progress<0.05){
+      const pulse = 0.35 + Math.sin(performance.now()/420 + (p.glowPhase || 0))*0.15;
+      ctx.save();
+      ctx.globalAlpha = clamp01(0.35 + pulse*0.3);
+      ctx.fillStyle = colorWithAlpha(glowColor, 0.55);
+      ctx.beginPath();
+      ctx.ellipse(0, bodyTop + h*0.2, w*0.8, h*0.9, 0, 0, Math.PI*2);
+      ctx.fill();
+      ctx.restore();
+    }
+    if(progress>0){
+      const innerGlow = ctx.createLinearGradient(0, bodyTop, 0, bodyTop + h*0.6);
+      innerGlow.addColorStop(0, colorWithAlpha(accentColor, 0.65));
+      innerGlow.addColorStop(1, colorWithAlpha(accentColor, 0));
+      ctx.fillStyle = innerGlow;
+      ctx.beginPath();
+      ctx.moveTo(-w*0.48, bodyTop + h*0.1);
+      ctx.lineTo(w*0.48, bodyTop + h*0.1);
+      ctx.lineTo(w*0.44, bodyBottom - h*0.15);
+      ctx.quadraticCurveTo(0, bodyBottom - h*0.05, -w*0.44, bodyBottom - h*0.15);
+      ctx.closePath();
+      ctx.fill();
+    }
+    const bodyGrad = ctx.createLinearGradient(0, bodyTop, 0, bodyBottom);
+    bodyGrad.addColorStop(0, shadeColor(baseColor, progress>0 ? 0.05 : 0.18));
+    bodyGrad.addColorStop(0.6, baseColor);
+    bodyGrad.addColorStop(1, shadeColor(shadowColor, -0.25));
+    ctx.fillStyle = bodyGrad;
+    ctx.beginPath();
+    ctx.moveTo(-w*0.5, bodyTop);
+    ctx.lineTo(w*0.5, bodyTop);
+    ctx.lineTo(w*0.46, bodyBottom);
+    ctx.quadraticCurveTo(0, bodyBottom + h*0.2, -w*0.46, bodyBottom);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = colorWithAlpha(shadowColor, 0.75);
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.fillStyle = trimColor;
+    const bandTop = bodyTop + h*0.18;
+    const bandHeight = h*0.16;
+    ctx.fillRect(-w*0.52, bandTop, w*1.04, bandHeight);
+    ctx.fillStyle = colorWithAlpha(hingeColor, 0.85);
+    ctx.fillRect(-w*0.12, bodyTop, w*0.24, bodyBottom - bodyTop);
+    ctx.fillStyle = shadeColor(hingeColor, -0.1);
+    const lockHeight = h*0.35;
+    ctx.fillRect(-w*0.11, bandTop + bandHeight*0.45, w*0.22, lockHeight);
+    ctx.fillStyle = shadeColor(trimColor, -0.1);
+    ctx.fillRect(-w*0.07, bandTop + bandHeight*0.58, w*0.14, lockHeight*0.6);
+    ctx.fillStyle = colorWithAlpha(accentColor, 0.9);
+    ctx.beginPath();
+    ctx.arc(0, bandTop + bandHeight + lockHeight*0.45, w*0.09, 0, Math.PI*2);
+    ctx.fill();
+    ctx.save();
+    ctx.translate(0, bodyTop);
+    ctx.rotate(-progress * 1.05);
+    ctx.translate(0, -lidHeight);
+    const lidGrad = ctx.createLinearGradient(0, -lidHeight*0.2, 0, lidHeight*0.8);
+    lidGrad.addColorStop(0, shadeColor(baseColor, 0.25));
+    lidGrad.addColorStop(0.7, baseColor);
+    lidGrad.addColorStop(1, shadeColor(shadowColor, -0.2));
+    ctx.fillStyle = lidGrad;
+    ctx.beginPath();
+    ctx.moveTo(-w*0.5, 0);
+    ctx.lineTo(w*0.5, 0);
+    ctx.lineTo(w*0.46, lidHeight);
+    ctx.quadraticCurveTo(0, lidHeight + h*0.12, -w*0.46, lidHeight);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = colorWithAlpha(shadowColor, 0.7);
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.fillStyle = colorWithAlpha(trimColor, 0.85);
+    ctx.fillRect(-w*0.5, lidHeight*0.18, w, lidHeight*0.2);
+    ctx.restore();
+    if(progress>=1 && p.variant==='gold'){
+      ctx.save();
+      ctx.globalAlpha = 0.35;
+      ctx.strokeStyle = colorWithAlpha(glowColor, 0.85);
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      const sparkle = performance.now()/180 + (p.glowPhase || 0);
+      for(let i=0;i<4;i++){
+        const ang = sparkle + i*Math.PI/2;
+        const sx = Math.cos(ang) * w*0.15;
+        const sy = Math.sin(ang) * w*0.15;
+        ctx.moveTo(sx, bandTop - h*0.1);
+        ctx.lineTo(sx*1.1, bandTop - h*0.25);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+    ctx.restore();
+  }
   function drawHeartPickup(p){
     const t = performance.now()/360;
     const wobble = Math.sin(t) * 0.08;
@@ -18139,29 +18563,54 @@
       ctx.arc(-r*0.25,0,r*0.2,0,Math.PI*2);
       ctx.fill();
     } else if(type==='coin'){
-      const coin = ctx.createRadialGradient(-r*0.25,-r*0.35,r*0.18,0,0,r*0.95);
-      coin.addColorStop(0, '#fff7cc');
-      coin.addColorStop(0.4, '#facc15');
-      coin.addColorStop(1, '#d97706');
-      ctx.fillStyle = coin;
+      const outer = ctx.createLinearGradient(0, -r*0.9, 0, r*1.05);
+      outer.addColorStop(0, '#fff8c5');
+      outer.addColorStop(0.45, '#facc15');
+      outer.addColorStop(1, '#b45309');
+      ctx.fillStyle = outer;
       ctx.beginPath();
-      ctx.ellipse(0,0,r*0.95,r*0.82,0,0,Math.PI*2);
+      ctx.ellipse(0,0,r*0.92,r*0.78,0,0,Math.PI*2);
       ctx.fill();
-      ctx.strokeStyle = colorWithAlpha('#7c2d12',0.6);
-      ctx.lineWidth = Math.max(1.1, r*0.1);
+      ctx.strokeStyle = colorWithAlpha('#78350f',0.75);
+      ctx.lineWidth = Math.max(1.2, r*0.12);
       ctx.stroke();
-      const rim = ctx.createLinearGradient(-r,0,r,0);
-      rim.addColorStop(0, colorWithAlpha('#fde68a',0.65));
-      rim.addColorStop(0.5, colorWithAlpha('#fff8dc',0.35));
-      rim.addColorStop(1, colorWithAlpha('#fde68a',0.65));
-      ctx.fillStyle = rim;
+      const rimFill = ctx.createLinearGradient(-r,0,r,0);
+      rimFill.addColorStop(0, '#fde68a');
+      rimFill.addColorStop(0.5, '#fff9da');
+      rimFill.addColorStop(1, '#fde68a');
+      ctx.fillStyle = rimFill;
       ctx.beginPath();
-      ctx.ellipse(0,0,r*0.72,r*0.62,0,0,Math.PI*2);
+      ctx.ellipse(0,0,r*0.78,r*0.64,0,0,Math.PI*2);
       ctx.fill();
-      ctx.fillStyle = colorWithAlpha('#7c2d12',0.7);
-      ctx.fillRect(-r*0.18,-r*0.7,r*0.36,r*1.4);
-      ctx.fillStyle = colorWithAlpha('#fef3c7',0.8);
-      ctx.fillRect(-r*0.08,-r*0.68,r*0.16,r*1.36);
+      ctx.strokeStyle = colorWithAlpha('#fef3c7',0.75);
+      ctx.lineWidth = Math.max(1, r*0.08);
+      ctx.beginPath();
+      ctx.ellipse(0,0,r*0.78,r*0.64,0,0,Math.PI*2);
+      ctx.stroke();
+      const inset = ctx.createLinearGradient(0, -r*0.6, 0, r*0.7);
+      inset.addColorStop(0, '#fef9c3');
+      inset.addColorStop(0.4, '#fde047');
+      inset.addColorStop(1, '#f59e0b');
+      ctx.fillStyle = inset;
+      ctx.beginPath();
+      ctx.ellipse(0,0,r*0.56,r*0.46,0,0,Math.PI*2);
+      ctx.fill();
+      ctx.fillStyle = colorWithAlpha('#7c2d12',0.6);
+      const stripeHeight = r*0.08;
+      for(let i=0;i<3;i++){
+        const y = -r*0.24 + i*stripeHeight*1.35;
+        ctx.fillRect(-r*0.48, y, r*0.96, stripeHeight*0.7);
+      }
+      ctx.fillStyle = colorWithAlpha('#fde68a',0.7);
+      ctx.fillRect(-r*0.48, -r*0.3, r*0.96, stripeHeight*0.5);
+      ctx.fillRect(-r*0.48, r*0.05, r*0.96, stripeHeight*0.5);
+      const highlight = ctx.createRadialGradient(-r*0.25,-r*0.28,r*0.12,0,0,r*0.9);
+      highlight.addColorStop(0, colorWithAlpha('#fff7da',0.9));
+      highlight.addColorStop(1, colorWithAlpha('#fff7da',0));
+      ctx.fillStyle = highlight;
+      ctx.beginPath();
+      ctx.ellipse(0,0,r*0.92,r*0.78,0,0,Math.PI*2);
+      ctx.fill();
     }
     ctx.restore();
   }


### PR DESCRIPTION
## Summary
- add silver and gold chest variants with spawn logic, loot rolls, and opening rules including key consumption and persistence control
- integrate chest physics, animation, and rendering plus hook into pickup collision handling and room transitions
- refresh coin artwork and tweak pickup physics so resources respond to pushes and explosions with mass-aware impulses

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e617165144832cb9714da7f0b9ec96